### PR TITLE
chore: update test page with local dev defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
       // baseUrl: "https://sectional-delightsomely-thiago.ngrok-free.dev/api/v1/",
       socketUrl: "ws://localhost:8000",
       baseUrl: "http://localhost:8000/api/v1/",
-      token: "543ebfa15b57b6bda627605da693554fe020cb29",
-      org_id: "3",
+      token: "memox-local-embed-token-not-for-prod",
+      org_id: "1",
       // ---
       title: "Container One",
       welcomeMessage: "Welcome! This is a production test of the chat system.",


### PR DESCRIPTION
## Summary
- Update `index.html` test page token to use the deterministic embed service token (`memox-local-embed-token-not-for-prod`)
- Update `org_id` to `"1"` to match default local dev org

## Context
Part of the unified docker-compose setup in memox-workspace. The test page at `localhost:8080` now works out of the box with `make up`.

## Test plan
- [ ] Open `localhost:8080` — widget loads and connects to backend
- [ ] Send a message — agent responds without 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)