### PR TITLE
fix(embed): wire theme.primary to launcher/header CSS variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,29 @@ function init(): void {
     document.body.appendChild(host);
   }
 
+  // --- Theme variable overrides ---
+  // The base stylesheet uses CSS custom properties ``--p`` (primary)
+  // and ``--ph`` (primary hover) for the launcher gradient, header
+  // gradient, send button, focus rings, etc. Without this injection
+  // those defaults to Memox purple and any ``theme.primary`` config
+  // is ignored on those surfaces. Also wires ``theme.headerBg`` and
+  // ``theme.sendBtnHover`` which are declared in the type but never
+  // consumed by the base CSS otherwise.
+  if (theme.primary || theme.sendBtnHover || theme.headerBg) {
+    const overrideStyle = document.createElement('style');
+    const primary = theme.primary;
+    const hover = theme.sendBtnHover || theme.primary;
+    const headerBg = theme.headerBg;
+    const headerText = theme.headerText;
+    const lines: string[] = [];
+    if (primary) lines.push(`--p: ${primary};`);
+    if (hover) lines.push(`--ph: ${hover};`);
+    overrideStyle.textContent = `:host { ${lines.join(' ')} }
+${headerBg ? `.mcx-header { background: ${headerBg} !important; }` : ''}
+${headerText ? `.mcx-header, .mcx-header * { color: ${headerText} !important; }` : ''}`;
+    root.appendChild(overrideStyle);
+  }
+
   // --- Create UI ---
   const widget = createWidgetContainer(config);
   const { messagesEl, scrollToBottom, forceScrollToBottom, checkScrollPosition, scrollBtn } = createMessageList();

--- a/src/ui/forms/lead-capture-form.ts
+++ b/src/ui/forms/lead-capture-form.ts
@@ -116,11 +116,13 @@ export function createLeadCaptureForm(
   }
 
   function addBotBubble(text: string): void {
+    const theme = config.theme || {};
+    const strokeColor = theme.botAvatarSvgColor || theme.primary || '#6366f1';
     const group = document.createElement('div');
     group.className = 'mcx-msg-group';
     group.innerHTML = `
       <div class="mcx-avatar mcx-avatar--bot">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2.2">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.2">
           <circle cx="12" cy="12" r="3"/>
           <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
         </svg>


### PR DESCRIPTION
## Summary
The base stylesheet uses two CSS custom properties — `--p` (primary) and `--ph` (primary hover) — for the launcher gradient, header gradient, send button, focus rings, etc. They were hardcoded to Memox purple `#8349FF`/`#6C2BD9` and **never wired to `theme.primary` from config**. Result: every V3 customer (Container One, etc.) renders purple regardless of their theme settings.

Real customer impact — Container One has a red `#ee3028` brand and after dropping in v3.0.4 they're still seeing Memox purple on the launcher bubble and chat header.

## Fix
- Inject a per-instance `<style>:host { --p; --ph; }</style>` after the base CSS in `src/index.ts`, sourced from `theme.primary` and `theme.sendBtnHover`.
- Add `!important` overrides for `.mcx-header { background }` and color when the user supplies `theme.headerBg` / `theme.headerText` (these were declared in types but never consumed).
- Wire the lead-capture form's bot-avatar SVG to `theme.botAvatarSvgColor || theme.primary` (was hardcoded `#6366f1`).

## Test plan
- [x] Local test page (Container One red theme) — launcher, header, send button, lead-form avatar all render red after the fix
- [x] Existing customers with no theme.primary set fall back to the previous Memox purple defaults (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)