### PR TITLE
fix(embed): default apiBase to hub.memox.io (api.memox.io does not exist)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,11 @@ async function init(): Promise<void> {
   // local config provides everything else. Falls through to {} on failure
   // so the widget always boots with at least the local defaults.
   const localConfig = mergeConfig(defaultConfig, userConfig);
-  const apiBase = localConfig.apiBase || localConfig.apiUrl || 'https://api.memox.io';
+  // Production hub hostname. ``api.memox.io`` does not resolve — confirmed
+  // against ``repos/memox-hub/deploy/k8s/README.md`` (Prod: hub.memox.io,
+  // Dev: hub-dev.memox.io). Without this default a customer pasting only
+  // ``embedId`` would silently fail DNS on every init request.
+  const apiBase = localConfig.apiBase || localConfig.apiUrl || 'https://hub.memox.io';
   const serverConfig = await fetchInitConfig(localConfig.embedId ?? null, apiBase);
   const config = mergeConfig(localConfig, serverConfig as Partial<ChatEmbedConfig>);
   // Scope localStorage to this embed instance — must run before any


### PR DESCRIPTION
## Summary
- The widget defaults ``apiBase`` to ``https://api.memox.io`` when a customer omits it. That hostname does not resolve.
- Production hub is ``hub.memox.io``; dev is ``hub-dev.memox.io`` (per ``repos/memox-hub/deploy/k8s/README.md``).
- With the embedId-only public snippet shipped in v3.0.7, customers rely on this default — meaning every paste-in-page snippet would currently fail DNS on the first init POST.

## Change
- ``src/index.ts``: default ``apiBase`` → ``https://hub.memox.io``.

Bundle unchanged at 131.69 kB raw / 40.74 kB gzip.

## Test plan
- [ ] CI build passes
- [ ] Existing ``init.test.ts`` still green (test fixtures keep ``api.memox.io`` because they mock ``fetch`` — the host string is just data)
- [ ] After release as v3.0.8, paste only ``{embedId}`` into a non-localhost page → init resolves, WS connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)