### PR TITLE
fix(release): npm run build must run vite, not legacy V1 terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "terser chat-embed.js --compress --mangle -o chat-embed-min.js",
+    "build": "vite build",
+    "build:v1-legacy": "terser chat-embed.js --compress --mangle -o chat-embed-min.js",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

``package.json`` had ``"build": "terser chat-embed.js ..."`` left over from the V1 era. The release workflow's ``npm run build`` was producing the V1 minified file, not the V3 Vite bundle — so every ``dist/chat-embed.js`` commit in the recent releases was just **re-committing whatever bytes already happened to be in dist** (the workflow uses ``git add -f`` but nothing actually wrote a new file).

That's why:
- v3.0.7 happened to ship the runtime-fields lift (someone manually ran ``vite build`` before triggering it)
- v3.0.8 still ships ``api.memox.io`` as default — the PR #39 fix never reached the CDN.

## Changes

- ``build``: ``vite build`` (was: legacy V1 terser)
- ``build:v1-legacy``: terser (preserved for one-off needs; V1 is frozen)

## Test plan
- [x] ``vite build`` regenerates ``dist/chat-embed.js`` at 131.69 kB raw / 40.74 kB gzip with ``hub.memox.io`` baked in.
- [ ] After merge: trigger v3.0.9 release — the workflow now rebuilds dist correctly.
- [ ] Verify ``@v3`` CDN URL after release: ``grep hub.memox.io`` should match, ``api.memox.io`` should NOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)