### PR TITLE
feat(embed): camelize theme tokens from server init response

### DIFF
--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchInitConfig } from './init';
+import { fetchInitConfig, normalizeServerConfig } from './init';
 
 describe('fetchInitConfig', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -131,5 +131,37 @@ describe('fetchInitConfig', () => {
     const result = await fetchInitConfig('emb_test123', 'https://api.memox.io');
     expect(result).toEqual({});
     expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeServerConfig — theme snake→camel bridge', () => {
+  it('aliases snake_case theme tokens to camelCase so widget UI reads pick them up', () => {
+    const out = normalizeServerConfig({
+      theme: {
+        user_bubble: '#ee3028',
+        bot_avatar_svg_color: '#8349ff',
+        handover_notification_bg: '#f6e3e3',
+        // Already-camel keys must NOT be clobbered.
+        primary: '#aaa',
+      },
+    });
+    expect(out.theme.userBubble).toBe('#ee3028');
+    expect(out.theme.botAvatarSvgColor).toBe('#8349ff');
+    expect(out.theme.handoverNotificationBg).toBe('#f6e3e3');
+    // Both shapes co-exist so applyTheme's snake_case branch still works.
+    expect(out.theme.user_bubble).toBe('#ee3028');
+    expect(out.theme.primary).toBe('#aaa');
+  });
+
+  it('leaves non-theme block untouched when theme is missing', () => {
+    const out = normalizeServerConfig({ welcome_message: 'hi' });
+    expect(out.theme).toBeUndefined();
+    expect(out.welcomeMessage).toBe('hi');
+  });
+
+  it('does not blow up on an array-typed theme (defensive)', () => {
+    const out = normalizeServerConfig({ theme: ['oops'] as unknown as Record<string, unknown> });
+    // Array passes through untouched — guards against future bad payloads.
+    expect(Array.isArray(out.theme)).toBe(true);
   });
 });

--- a/src/connection/init.ts
+++ b/src/connection/init.ts
@@ -126,5 +126,33 @@ export function normalizeServerConfig(serverConfig: Record<string, any>): Record
     out.leadCaptureConfig = serverConfig.lead_capture;
     out.leadCapture = !!serverConfig.lead_capture.enabled;
   }
+
+  // Dashboard persists theme tokens in snake_case (``user_bubble``,
+  // ``bot_avatar_svg_color``, etc.) into the JSON column, but every
+  // widget UI component reads them in camelCase (``theme.userBubble``).
+  // ``applyTheme`` accepts both via its tolerant ``pick()``, but the
+  // inline reads in message-bubble / index.ts don't. Camelize the
+  // ``theme`` block while preserving the snake_case keys so applyTheme's
+  // existing branch logic (``hasServerKeys``) keeps working — both
+  // shapes live side-by-side on the same object.
+  if (serverConfig.theme && typeof serverConfig.theme === 'object' && !Array.isArray(serverConfig.theme)) {
+    out.theme = camelizeTopLevel(serverConfig.theme as Record<string, any>);
+  }
+  return out;
+}
+
+/**
+ * Add camelCase aliases for snake_case keys on a single-level object
+ * without mutating the original. Used to bridge the dashboard's
+ * snake_case ``theme_overrides`` JSON to the widget's camelCase reads.
+ */
+function camelizeTopLevel(obj: Record<string, any>): Record<string, any> {
+  const out: Record<string, any> = { ...obj };
+  for (const [k, v] of Object.entries(obj)) {
+    if (k.includes('_')) {
+      const camel = snakeToCamelKey(k);
+      if (!(camel in out)) out[camel] = v;
+    }
+  }
   return out;
 }


### PR DESCRIPTION
## Summary

The dashboard persists ``EmbedConfiguration.theme_overrides`` in snake_case (``user_bubble``, ``bot_avatar_svg_color``, ``handover_notification_bg``, …), but the widget reads theme tokens in camelCase off ``theme.userBubble`` / ``theme.botAvatarSvgColor`` in ``message-bubble.ts`` and ``index.ts``.

``applyTheme`` already handled both shapes via its ``pick()`` reader, but that's the CSS-var path — only ``primary``, ``send_btn_hover``, ``header_bg_color``, ``header_text_color`` flow through it. Bubbles, avatars, send button bg, handover banner, etc. are read directly off ``theme`` by widget UI code, so dashboard overrides for those tokens silently no-op'd.

## Change

Extend ``normalizeServerConfig`` to add camelCase aliases for every snake_case key on the nested ``theme`` block, preserving the snake_case keys so ``applyTheme``'s existing ``hasServerKeys`` branch logic keeps working. Same pattern as the existing top-level snake→camel pass, scoped to the theme block.

## Test plan
- [x] 3 new unit tests in ``init.test.ts`` (aliasing, missing-theme inert path, array-typed theme defensive guard).
- [x] ``vite build`` clean — 131.89 kB raw / 40.77 kB gzip (was 131.69 kB).
- [ ] After merge: release ``3.0.10`` and verify a dashboard-saved ``user_bubble`` paints in the rendered widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)