### PR TITLE
MMX-551: feat(widget) render assigned rep's photo as sales-rep avatar

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -282,6 +282,10 @@ export interface StoredMessage {
   isStreaming?: boolean;
   messageId?: string;
   senderName?: string | { name?: string };
+  // MMX-551: the assigned rep's profile photo URL, pushed in the
+  // handover WS frame by memox-hub. When set, the sales-rep avatar
+  // renders as this image instead of the default SVG placeholder.
+  senderPhotoUrl?: string;
   created_at?: string;
   lastChunkTime?: number;
 }

--- a/src/connection/websocket-manager.ts
+++ b/src/connection/websocket-manager.ts
@@ -14,6 +14,9 @@ export interface WsMessageData {
   is_complete?: boolean;
   created_at?: string;
   sender_name?: string;
+  // MMX-551: profile photo of the assigned sales rep. Surfaced as the
+  // rep avatar in the chat bubble after handover.
+  sender_photo_url?: string;
   assigned_user_name?: string;
   assigned_user_email?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -548,6 +548,9 @@ async function init(): Promise<void> {
         text: content,
         sender: 'sales_rep',
         senderName: (typeof data.sender === 'string' ? data.sender : data.sender_name) || 'Sales Representative',
+        // MMX-551: the assigned rep's profile photo (if they uploaded
+        // one). Falls back to default SVG avatar when empty.
+        senderPhotoUrl: data.sender_photo_url || undefined,
         isWelcomeMessage: false,
         created_at: formatTimeStamp(data.created_at || new Date().toISOString()),
       });

--- a/src/ui/messages/message-bubble.ts
+++ b/src/ui/messages/message-bubble.ts
@@ -8,7 +8,7 @@ export interface BubbleRefs {
   contentWrapper?: HTMLDivElement;
 }
 
-function createAvatar(sender: string, config: ChatEmbedConfig): HTMLDivElement {
+function createAvatar(sender: string, config: ChatEmbedConfig, photoUrl?: string): HTMLDivElement {
   const theme = config.theme || {};
   const av = document.createElement('div');
   av.className = `mcx-avatar mcx-avatar--${sender}`;
@@ -24,8 +24,29 @@ function createAvatar(sender: string, config: ChatEmbedConfig): HTMLDivElement {
   } else if (sender === 'sales_rep') {
     av.style.background = theme.salesRepAvatar || '#DBEAFE';
     av.style.border = theme.salesRepAvatarBorder || 'none';
-    const color = theme.salesRepAvatarSvgColor || theme.primary || '#8349FF';
-    av.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`;
+    // MMX-551: when memox-hub sends a sender_photo_url on the handover
+    // WS frame (the assigned rep uploaded a profile photo), render it
+    // here so customers see the rep's actual face. DOM API + isSafeImageUrl
+    // gate so a stray quote in the URL can't escape the src attribute.
+    if (photoUrl && isSafeImageUrl(photoUrl)) {
+      const img = document.createElement('img');
+      img.src = photoUrl;
+      img.alt = '';
+      img.style.width = '100%';
+      img.style.height = '100%';
+      img.style.objectFit = 'cover';
+      img.style.borderRadius = '50%';
+      img.onerror = () => {
+        const fallback = theme.salesRepAvatarSvgColor || theme.primary || '#8349FF';
+        av.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${fallback}" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`;
+      };
+      av.style.padding = '0';
+      av.style.overflow = 'hidden';
+      av.replaceChildren(img);
+    } else {
+      const color = theme.salesRepAvatarSvgColor || theme.primary || '#8349FF';
+      av.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`;
+    }
   } else {
     const bIcon = theme.botIcon || config.botIcon || {};
     av.style.width = bIcon.botIconAvatarWidth || '29px';
@@ -63,7 +84,11 @@ export function createMessageBubble(
   const container = document.createElement('div');
   container.className = `mcx-msg-group${msg.sender === 'user' ? ' mcx-msg-group--user' : ''}`;
 
-  const avatar = createAvatar(msg.sender === 'ai' ? 'bot' : msg.sender, config);
+  const avatar = createAvatar(
+    msg.sender === 'ai' ? 'bot' : msg.sender,
+    config,
+    msg.sender === 'sales_rep' ? msg.senderPhotoUrl : undefined,
+  );
   const bubble = document.createElement('div');
   bubble.className = 'mcx-msg-stack';
   if (msg.sender === 'user') bubble.classList.add('mcx-msg-stack--user');


### PR DESCRIPTION
## Summary

Widget slice of [MMX-551](https://memox.atlassian.net/browse/MMX-551). When the assigned sales rep has uploaded a profile photo, the chat embed now renders that photo as the round avatar on every sales-rep bubble in the conversation — instead of the generic SVG silhouette.

Pairs with:
- [memox-hub PR #366](https://github.com/Memox-Inc/memox-hub/pull/366) — adds `sender_photo_url` to the handover WS group_send payload + the upload endpoint
- [mmx-unified-chat PR #142](https://github.com/Memox-Inc/mmx-unified-chat/pull/142) — `/settings/profile` page that lets the rep upload the photo

## What's in this PR

- `StoredMessage.senderPhotoUrl` + `WsMessageData.sender_photo_url` typed in `config/types.ts` and `connection/websocket-manager.ts`
- `index.ts` pipes the field through when persisting a `sales_rep` message
- `createAvatar(sender='sales_rep')` in `ui/messages/message-bubble.ts`:
  - Renders an `<img>` when a photo URL is present, sized to fill the existing round avatar slot
  - Falls back to the existing SVG silhouette when empty — no regression for reps who haven't uploaded a photo
  - Uses `isSafeImageUrl()` + DOM API construction (matching the bot-avatar pattern) so a stray quote in the URL can't escape the `src` attribute and inject HTML into the shadow root
  - `onerror` handler swaps back to the SVG if the image 404s / CORS-blocks, so the bubble never shows a broken-image icon

## Test plan

- [x] `tsc --noEmit` clean
- [x] Existing `vitest` suite green (133/134 — the one pre-existing failure in `index.inline-mount.test.ts` is unrelated to this branch; verified by running it on `main`)
- [ ] Manual: customer-facing chat after handover from a rep with a photo set → photo renders in every rep bubble
- [ ] Manual: rep with no photo set → existing SVG avatar renders (no regression)
- [ ] Manual: bad / 404 photo URL → SVG fallback fires via `onerror`

## Release

After merge, cut a new patch tag (`gh workflow run release.yml -f version=3.0.11 -f set_active=true`) and update the customer-side embed URL pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MMX-551]: https://memox.atlassian.net/browse/MMX-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ