### PR TITLE
MMX-585: fix(embed) idempotent createInlineShadowHost (defense-in-depth)

### DIFF
--- a/src/ui/shadow-host.test.ts
+++ b/src/ui/shadow-host.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Shadow host idempotency tests (MMX-585).
+ *
+ * createInlineShadowHost (and its floating sibling) must NOT append a
+ * second host element when called twice against the same parent. Two
+ * hosts in a flex container produce two side-by-side widget halves —
+ * the user-visible symptom of the double-mount race.
+ */
+import { describe, expect, it } from 'vitest';
+import { createInlineShadowHost, createShadowHost } from './shadow-host';
+
+describe('createInlineShadowHost', () => {
+  it('creates a host with a closed shadow root on first call', () => {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const { host, root } = createInlineShadowHost(parent);
+    expect(host.id).toBe('memox-chat-embed-host');
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0]).toBe(host);
+    expect(root).toBeTruthy();
+    // The closed shadow root is not retrievable via host.shadowRoot.
+    expect(host.shadowRoot).toBeNull();
+  });
+
+  it('returns the same host and root when called twice on the same parent', () => {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const first = createInlineShadowHost(parent);
+    const second = createInlineShadowHost(parent);
+    expect(second.host).toBe(first.host);
+    expect(second.root).toBe(first.root);
+    expect(parent.children).toHaveLength(1);
+  });
+
+  it('creates a fresh host when the parent has no prior memox host', () => {
+    const parentA = document.createElement('div');
+    const parentB = document.createElement('div');
+    document.body.appendChild(parentA);
+    document.body.appendChild(parentB);
+    const a = createInlineShadowHost(parentA);
+    const b = createInlineShadowHost(parentB);
+    expect(b.host).not.toBe(a.host);
+    expect(parentA.children).toHaveLength(1);
+    expect(parentB.children).toHaveLength(1);
+  });
+
+  it('does not collide with a sibling host outside the parent', () => {
+    // A floating-mode host on document.body must not cause inline mode
+    // to skip creating its own host inside its parent.
+    const floatingHost = document.createElement('div');
+    floatingHost.id = 'memox-chat-embed-host';
+    document.body.appendChild(floatingHost);
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    const { host } = createInlineShadowHost(parent);
+    expect(host).not.toBe(floatingHost);
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0]).toBe(host);
+    floatingHost.remove();
+  });
+});
+
+describe('createShadowHost (floating mode)', () => {
+  it('returns the same host on a second call when the prior host is still in document.body', () => {
+    const first = createShadowHost();
+    document.body.appendChild(first.host);
+    const second = createShadowHost();
+    expect(second.host).toBe(first.host);
+    expect(second.root).toBe(first.root);
+    first.host.remove();
+  });
+});

--- a/src/ui/shadow-host.ts
+++ b/src/ui/shadow-host.ts
@@ -1,6 +1,50 @@
 import widgetCss from '../styles/widget.css?inline';
 
+// Closed shadow roots are not retrievable from outside the call site that
+// created them — there is no DOM API to re-open one. So we stash the
+// ShadowRoot on the host element via a non-enumerable property and use it
+// for idempotent reuse. This is the only safe way to honour "call again,
+// get the same host back" for closed-mode shadow DOM.
+const SHADOW_ROOT_REF = '__memoxChatEmbedShadowRoot';
+
+interface HostWithCachedRoot extends HTMLElement {
+  [SHADOW_ROOT_REF]?: ShadowRoot;
+}
+
+function attachStyledRoot(host: HTMLElement): ShadowRoot {
+  const root = host.attachShadow({ mode: 'closed' });
+  const style = document.createElement('style');
+  style.textContent = widgetCss;
+  root.appendChild(style);
+  (host as HostWithCachedRoot)[SHADOW_ROOT_REF] = root;
+  return root;
+}
+
+function findExistingHostIn(parent: ParentNode): HostWithCachedRoot | null {
+  // We append the host as a direct child of ``parent`` (or document.body
+  // for floating mode), so a linear scan of ``children`` is enough and
+  // avoids relying on ``:scope`` (which jsdom-based unit tests don't
+  // implement consistently across versions). querySelector would also
+  // match descendants, which is too loose — a host page can legitimately
+  // have its own ``#memox-chat-embed-host`` lower in the tree (e.g. a
+  // nested iframe content document we don't own).
+  for (const child of Array.from(parent.children) as HostWithCachedRoot[]) {
+    if (child.id === 'memox-chat-embed-host') return child;
+  }
+  return null;
+}
+
 export function createShadowHost(): { host: HTMLElement; root: ShadowRoot } {
+  // Floating mode mounts to ``document.body`` elsewhere in init() — if a
+  // previous bootstrap already left a host there, reuse it so a second
+  // init() (host page double-mounts the script tag, SPA-nav races,
+  // marketing widget + per-page widget overlapping) does not produce a
+  // second floating launcher.
+  const existing = findExistingHostIn(document.body);
+  if (existing && existing[SHADOW_ROOT_REF]) {
+    return { host: existing, root: existing[SHADOW_ROOT_REF]! };
+  }
+
   const host = document.createElement('div');
   host.id = 'memox-chat-embed-host';
   host.style.all = 'initial';
@@ -10,16 +54,24 @@ export function createShadowHost(): { host: HTMLElement; root: ShadowRoot } {
   host.style.right = '0';
   host.style.fontFamily = 'sans-serif';
 
-  const root = host.attachShadow({ mode: 'closed' });
-
-  const style = document.createElement('style');
-  style.textContent = widgetCss;
-  root.appendChild(style);
-
+  const root = attachStyledRoot(host);
   return { host, root };
 }
 
-export function createInlineShadowHost(parent: HTMLElement): { host: HTMLElement; root: ShadowRoot } {
+export function createInlineShadowHost(parent: HTMLElement): {
+  host: HTMLElement;
+  root: ShadowRoot;
+} {
+  // Idempotent: if init() runs twice against the same parent (e.g. a host
+  // page's React effect re-fires after the chat-embed.js network load was
+  // already in flight, so two scripts complete and both call init()), we
+  // must NOT append a second host. Two hosts in a flex container split
+  // the row and render two side-by-side widget halves. See MMX-585.
+  const existing = findExistingHostIn(parent);
+  if (existing && existing[SHADOW_ROOT_REF]) {
+    return { host: existing, root: existing[SHADOW_ROOT_REF]! };
+  }
+
   const host = document.createElement('div');
   host.id = 'memox-chat-embed-host';
   host.style.all = 'initial';
@@ -31,12 +83,7 @@ export function createInlineShadowHost(parent: HTMLElement): { host: HTMLElement
   host.style.overflow = 'hidden';
   host.style.fontFamily = 'sans-serif';
 
-  const root = host.attachShadow({ mode: 'closed' });
-
-  const style = document.createElement('style');
-  style.textContent = widgetCss;
-  root.appendChild(style);
-
+  const root = attachStyledRoot(host);
   parent.appendChild(host);
   return { host, root };
 }


### PR DESCRIPTION
## Summary

`createInlineShadowHost` (and `createShadowHost` for floating mode) unconditionally created a new host + `parent.appendChild`'d it on every call. When `init()` ran twice against the same parent — host page double-mounts the script tag, SPA navigation, a host React effect re-firing while the chat-embed.js network load is in flight — two `#memox-chat-embed-host` divs ended up inside the parent, splitting the flex row into two side-by-side widget halves.

Reproduced on memox.io/demo and confirmed by user on containerone.net. The website-side race that triggers double-init is fixed under MMX-586. This PR is the widget-side defense-in-depth so any host page that double-mounts the script — which we cannot prevent in customer code — still gets exactly one widget.

## Implementation

- Cache the closed `ShadowRoot` on the host element via a sentinel property (`__memoxChatEmbedShadowRoot`). Closed shadow roots have no DOM API for retrieval, so this is the only safe way to reuse one across calls.
- On entry, scan `parent.children` directly for `#memox-chat-embed-host`. If found AND has our cached root → reuse. Otherwise create fresh.
- Linear scan over `:scope`/`querySelector` because (a) jsdom doesn't implement `:scope` consistently, (b) plain `querySelector` matches descendants which is too loose — a host page can have its own `#memox-chat-embed-host` lower in the tree.

## Tests (`src/ui/shadow-host.test.ts`)

1. First call creates host + closed shadow root, attaches to parent
2. Second call on same parent returns same host + root, **no duplicate**
3. Different parents each get their own host (isolation)
4. A pre-existing floating host on `document.body` does not poison a sibling inline mount

Full vitest suite: **141 passed** (17 files). No regressions.

## Release

Once merged, cut a `v3.0.12` release via the workflow:
```bash
gh workflow run release.yml -f version=3.0.12 -f set_active=true
```

The `@v3` jsdelivr alias will resolve to v3.0.12 within a few minutes.

## Test plan

- [ ] Merge → cut v3.0.12 release
- [ ] Verify on memox.io marketing widget (already `@v3`) — single floating widget
- [ ] Verify on memox.io/demo/[persona] (will pick up via `@v3` after MMX-586 merge) — single inline widget
- [ ] Spot-check containerone.net embed — single widget (defense-in-depth coverage)
- [ ] Spot-check mmx-unified-chat /playground — single widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)