### PR TITLE
fix(embed) lead-capture form respects user-defined field order

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -143,6 +143,27 @@ export interface LeadFormHelperText {
   borderRadius?: string;
 }
 
+/**
+ * Per-field row inside ``leadCaptureConfig.fields``. Mirrors the
+ * Pydantic ``LeadCaptureField`` in
+ * memox-hub/memox_hub/embed_app/lead_capture_config.py and the
+ * ``LeadCaptureField`` type in mmx-unified-chat/services/embed.service.ts
+ * — keep the three in sync.
+ */
+export interface LeadCaptureFieldConfig {
+  key: string;
+  label: string;
+  type: 'text' | 'email' | 'phone' | 'number';
+  enabled: boolean;
+  required: boolean;
+  custom: boolean;
+  phone_options?: {
+    allowed_countries?: string[];
+    default_country?: string;
+    validation?: 'strict' | 'loose' | 'none';
+  };
+}
+
 // Launcher attractor system — mirrors the Pydantic LauncherConfig in
 // memox-hub/memox_hub/embed_app/launcher_config.py. Field names match
 // the wire format (snake_case) so a config fetched from /embed/init can
@@ -212,6 +233,20 @@ export interface ChatEmbedConfig {
   welcomeMessage?: string | null;
   welcomeMessageStyle?: WelcomeMessageStyle;
   leadCapture?: boolean;
+  /**
+   * Full lead-capture config object from the server (``/embed/init/``).
+   * Carries the per-field schema (key, label, type, enabled, required,
+   * custom, plus phone_options for the phone field) and the user-defined
+   * field order. The lead-capture form respects this order; if absent
+   * (legacy v1 config), the form falls back to the built-in defaults
+   * (name → email → phone → zip).
+   */
+  leadCaptureConfig?: {
+    enabled?: boolean;
+    mandatory?: boolean;
+    variant?: 'multi_step' | 'single_step';
+    fields?: LeadCaptureFieldConfig[];
+  };
   leadFormHelperText?: LeadFormHelperText;
   quickQuestions?: string[];
   quickQuestionsPermanent?: boolean;

--- a/src/ui/forms/lead-capture-form.test.ts
+++ b/src/ui/forms/lead-capture-form.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Lead-capture form rendering tests.
+ *
+ * Specifically: the form must respect the user-defined field order +
+ * enabled flag + label overrides from
+ * ``config.leadCaptureConfig.fields`` (the v2 server config shape).
+ * Bug fixed here was a hardcoded ``steps`` array in
+ * ``createLeadCaptureForm`` that ignored the config entirely, so
+ * reordering email-above-name in the dashboard never reflected in the
+ * live widget preview.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createLeadCaptureForm } from './lead-capture-form';
+import type { ChatEmbedConfig, LeadCaptureFieldConfig } from '../../config/types';
+
+function fields(...rows: Partial<LeadCaptureFieldConfig>[]): LeadCaptureFieldConfig[] {
+  return rows.map((r) => ({
+    key: r.key ?? '',
+    label: r.label ?? r.key ?? '',
+    type: r.type ?? 'text',
+    enabled: r.enabled ?? true,
+    required: r.required ?? true,
+    custom: r.custom ?? false,
+    ...(r.phone_options ? { phone_options: r.phone_options } : {}),
+  }));
+}
+
+function readFirstStepLabel(el: HTMLElement): string | null {
+  return el.querySelector('.mcx-lead-field-label')?.textContent?.trim() ?? null;
+}
+
+function readDotCount(el: HTMLElement): number {
+  return el.querySelectorAll('.mcx-lead-dot').length;
+}
+
+describe('createLeadCaptureForm — field order', () => {
+  it('falls back to built-in default order when no leadCaptureConfig is provided', () => {
+    const config: ChatEmbedConfig = {};
+    const el = createLeadCaptureForm(config, vi.fn());
+
+    // Default is 3 visible steps (name → email → phone), zip omitted.
+    expect(readDotCount(el)).toBe(3);
+    // First field shown should be the name input.
+    expect(readFirstStepLabel(el)).toContain('Full name');
+  });
+
+  it('honors user-defined field order — email first, then name', () => {
+    const config: ChatEmbedConfig = {
+      leadCaptureConfig: {
+        enabled: true,
+        fields: fields(
+          { key: 'email', label: 'Your email', type: 'email' },
+          { key: 'name', label: 'Your name', type: 'text' },
+        ),
+      },
+    };
+
+    const el = createLeadCaptureForm(config, vi.fn());
+    expect(readDotCount(el)).toBe(2);
+    // The form starts at step 0 — first rendered input must be email.
+    const firstLabel = readFirstStepLabel(el);
+    expect(firstLabel).toContain('Your email');
+    expect(firstLabel).not.toContain('Your name');
+  });
+
+  it('filters out disabled fields from the step sequence', () => {
+    const config: ChatEmbedConfig = {
+      leadCaptureConfig: {
+        enabled: true,
+        fields: fields(
+          { key: 'name', label: 'Name', type: 'text', enabled: true },
+          { key: 'email', label: 'Email', type: 'email', enabled: false },
+          { key: 'phone', label: 'Phone', type: 'phone', enabled: true },
+        ),
+      },
+    };
+
+    const el = createLeadCaptureForm(config, vi.fn());
+    // 3 fields in config but email is disabled → 2 steps.
+    expect(readDotCount(el)).toBe(2);
+  });
+
+  it('uses the user-provided label override on a built-in key', () => {
+    const config: ChatEmbedConfig = {
+      leadCaptureConfig: {
+        enabled: true,
+        fields: fields({ key: 'name', label: 'Trade name', type: 'text' }),
+      },
+    };
+
+    const el = createLeadCaptureForm(config, vi.fn());
+    expect(readFirstStepLabel(el)).toContain('Trade name');
+  });
+
+  it('renders custom (user-defined) fields with their label', () => {
+    const config: ChatEmbedConfig = {
+      leadCaptureConfig: {
+        enabled: true,
+        fields: fields({
+          key: 'f_company',
+          label: 'Company name',
+          type: 'text',
+          custom: true,
+          required: true,
+        }),
+      },
+    };
+
+    const el = createLeadCaptureForm(config, vi.fn());
+    expect(readDotCount(el)).toBe(1);
+    expect(readFirstStepLabel(el)).toContain('Company name');
+  });
+
+  it('emits onComplete(null) instantly when every field is disabled', async () => {
+    const onComplete = vi.fn();
+    const config: ChatEmbedConfig = {
+      leadCaptureConfig: {
+        enabled: true,
+        fields: fields(
+          { key: 'name', label: 'Name', type: 'text', enabled: false },
+          { key: 'email', label: 'Email', type: 'email', enabled: false },
+        ),
+      },
+    };
+
+    createLeadCaptureForm(config, onComplete);
+
+    // queueMicrotask fires before the next macrotask — flush via a Promise.
+    await Promise.resolve();
+    expect(onComplete).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/ui/forms/lead-capture-form.ts
+++ b/src/ui/forms/lead-capture-form.ts
@@ -1,4 +1,4 @@
-import type { ChatEmbedConfig } from '../../config/types';
+import type { ChatEmbedConfig, LeadCaptureFieldConfig } from '../../config/types';
 import { sanitizeInput } from '../../utils/dom';
 import { validateName, validateEmail, validatePhone, validateZip, normalizePhoneE164 } from './validation';
 import { createPhoneField } from './phone-field';
@@ -9,6 +9,8 @@ export interface LeadData {
   email: string;
   phone: string;
   zip: string;
+  /** Custom fields keyed by their config ``key`` (e.g. ``f_abc123``). */
+  customFields?: Record<string, string>;
   timestamp: string;
   userAgent: string;
   platform: string;
@@ -27,55 +29,135 @@ interface StepDef {
   helpText: string;
   validate: (val: string, extra?: unknown) => string | null;
   isPhone?: boolean;
+  /** Built-in keys we know how to render natively (name/email/phone/zip);
+   * everything else is a custom user-defined field rendered as a generic
+   * text input. */
+  custom?: boolean;
 }
 
-export function createLeadCaptureForm(
-  config: ChatEmbedConfig,
-  onComplete: (lead: LeadData | null) => void,
-): HTMLDivElement {
-  const steps: StepDef[] = [
-    {
+/**
+ * Build the per-step definitions for the lead-capture form.
+ *
+ * If ``config.leadCaptureConfig.fields`` is present (v2 server config),
+ * respect the user's field order, ``enabled`` flag, and ``label``
+ * overrides. If absent (legacy v1 boolean ``leadCapture``), fall back
+ * to the built-in default order: name \u2192 email \u2192 phone \u2192 zip (with zip
+ * disabled by default so the form is 3 steps).
+ *
+ * Built-in field keys (``name``/``email``/``phone``/``zip``) reuse the
+ * widget's typed validators and existing UX (phone country picker, zip
+ * format check). Custom fields render as a generic text input with the
+ * user-defined label.
+ */
+function buildSteps(config: ChatEmbedConfig): StepDef[] {
+  const builtins: Record<string, Omit<StepDef, 'label'>> = {
+    name: {
       field: 'name',
       botQuestion: '\u{1F44B} Welcome! I need a few quick details to get started. What\'s your name?',
-      label: 'Full name',
       type: 'text',
       placeholder: 'Full name',
       buttonText: 'Continue \u2192',
       helpText: '\u{1F512} Required to access the chat',
       validate: (v) => validateName(v),
     },
-    {
+    email: {
       field: 'email',
-      botQuestion: '', // dynamic: "Nice to meet you, {name}! What's your email?"
-      label: 'Email address',
+      botQuestion: '', // dynamic \u2014 uses collected name if available
       type: 'email',
       placeholder: 'you@company.com',
       buttonText: 'Continue \u2192',
       helpText: '\u{1F512} Required to access the chat',
       validate: (v) => validateEmail(v),
     },
-    {
+    phone: {
       field: 'phone',
       botQuestion: 'Great! What\'s your phone number?',
-      label: 'Phone number',
       type: 'tel',
       placeholder: '(555) 000-0000',
       buttonText: 'Continue \u2192',
-      helpText: '\u{1F512} Step 3 of 4',
+      helpText: '\u{1F512} Phone number',
       validate: (v, extra) => validatePhone(v, extra as CountryEntry),
       isPhone: true,
     },
-    {
+    zip: {
       field: 'zip',
       botQuestion: 'Almost done! What\'s your zip code?',
-      label: 'Zip code',
       type: 'text',
       placeholder: 'e.g. 75201',
-      buttonText: 'Get Started \u2192',
-      helpText: '\u{1F512} Final step',
+      buttonText: 'Continue \u2192',
+      helpText: '\u{1F512} Zip code',
       validate: (v) => validateZip(v),
     },
-  ];
+  };
+
+  const fields: LeadCaptureFieldConfig[] | undefined = config.leadCaptureConfig?.fields;
+
+  // Legacy / v1 path \u2014 no field config available, use built-in default
+  // order (without zip, matching prior visible behavior).
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return [
+      { ...builtins.name, label: 'Full name' },
+      { ...builtins.email, label: 'Email address' },
+      { ...builtins.phone, label: 'Phone number' },
+    ];
+  }
+
+  const steps: StepDef[] = [];
+  for (const f of fields) {
+    if (!f || f.enabled === false) continue;
+
+    const builtin = builtins[f.key];
+    if (builtin && !f.custom) {
+      steps.push({ ...builtin, label: f.label || builtin.field });
+      continue;
+    }
+
+    // Custom field \u2014 generic non-empty text input. We don't infer a
+    // specialised validator from ``f.type`` for custom fields because
+    // the dashboard's "Add field" UI doesn't expose phone/email
+    // semantics on custom keys yet (see LeadCaptureSection.tsx);
+    // adding that mapping is a follow-up.
+    steps.push({
+      field: f.key,
+      botQuestion: `${f.label}?`,
+      label: f.label || f.key,
+      type: f.type === 'number' ? 'text' : (f.type || 'text'),
+      placeholder: f.label || '',
+      buttonText: 'Continue \u2192',
+      helpText: f.required ? '\u{1F512} Required' : 'Optional',
+      validate: (v) => (v && v.trim().length > 0 ? null : `${f.label} is required`),
+      custom: true,
+    });
+  }
+
+  // Replace the last step's button label to signal completion.
+  if (steps.length > 0) {
+    steps[steps.length - 1] = {
+      ...steps[steps.length - 1],
+      buttonText: 'Get Started \u2192',
+      helpText: '\u{1F512} Final step',
+    };
+  }
+
+  return steps;
+}
+
+export function createLeadCaptureForm(
+  config: ChatEmbedConfig,
+  onComplete: (lead: LeadData | null) => void,
+): HTMLDivElement {
+  const steps: StepDef[] = buildSteps(config);
+
+  // Defensive: if every field is disabled (or config is malformed)
+  // the form would render zero steps and never call ``onComplete``,
+  // stranding the visitor on a blank panel. Bail out by treating the
+  // form as instantly complete with empty data \u2014 the caller (init.ts)
+  // can decide whether to skip lead capture entirely upstream.
+  if (steps.length === 0) {
+    const empty = document.createElement('div');
+    queueMicrotask(() => onComplete(null));
+    return empty;
+  }
 
   let currentStep = 0;
   const collected: Record<string, string> = {};
@@ -231,11 +313,21 @@ export function createLeadCaptureForm(
         inputArea.appendChild(successDiv);
 
         setTimeout(() => {
+          // Pull custom (non-builtin) values into a dedicated bag so
+          // downstream consumers can read them without colliding with
+          // the four canonical keys.
+          const builtinKeys = new Set(['name', 'email', 'phone', 'zip']);
+          const customFields: Record<string, string> = {};
+          for (const [k, v] of Object.entries(collected)) {
+            if (!builtinKeys.has(k)) customFields[k] = sanitizeInput(v);
+          }
+
           const lead: LeadData = {
-            name: sanitizeInput(collected.name),
-            email: sanitizeInput(collected.email),
-            phone: collected.phone,
-            zip: sanitizeInput(collected.zip),
+            name: sanitizeInput(collected.name || ''),
+            email: sanitizeInput(collected.email || ''),
+            phone: collected.phone || '',
+            zip: sanitizeInput(collected.zip || ''),
+            customFields,
             timestamp: new Date().toISOString(),
             userAgent: navigator.userAgent,
             platform: navigator.platform,
@@ -251,8 +343,13 @@ export function createLeadCaptureForm(
       // Next step
       const nextStep = steps[currentStep];
       let question = nextStep.botQuestion;
-      if (nextStep.field === 'email') {
+      if (nextStep.field === 'email' && collected.name) {
+        // Personalize the email prompt only when we've already collected
+        // a name. If email comes before name in the user-configured
+        // order, fall back to the generic prompt.
         question = `Nice to meet you, ${sanitizeInput(collected.name)}! What's your email?`;
+      } else if (nextStep.field === 'email' && !question) {
+        question = 'What\'s your email?';
       }
       addBotBubble(question);
       renderInputForStep(nextStep);


### PR DESCRIPTION
## Summary

The widget's lead-capture form hardcoded its step sequence (`name → email → phone → zip`) inside `createLeadCaptureForm` and completely ignored the field config the dashboard already persists. Reordering email above name in the dashboard saved fine, the live preview re-mounted, but the widget still rendered `name` first.

This fix wires the form to read `config.leadCaptureConfig.fields` (the server's camelized v2 lead-capture payload) and respect:
- the user's order
- the `enabled` flag (disabled fields are skipped)
- the user-defined `label`
- the `custom: true` flag — custom fields render as a generic text input with a non-empty validator

Built-in keys (`name`/`email`/`phone`/`zip`) keep their typed validators and UX (phone country picker, zip format). Falls back to the built-in default order when no `leadCaptureConfig` is provided (legacy `leadCapture: boolean` clients).

Drive-bys:
- `LeadData` gains a `customFields` bag for non-builtin values
- Email greeting (`Nice to meet you, {name}!`) only personalises when name was already collected — if email comes first now, it falls back to a plain prompt instead of `Nice to meet you, undefined!`
- `LeadCaptureFieldConfig` type added + `leadCaptureConfig` declared on `ChatEmbedConfig`

## Repro

Reported against dashboard preview https://mmx-unified-chat-pr-147.preview.memox.io/agents/1 — drag email above name in the LeadCaptureSection editor, save, watch the live preview re-init… name still first.

Source files touched by this PR:
- `src/ui/forms/lead-capture-form.ts` — build steps from config
- `src/config/types.ts` — declare `leadCaptureConfig` + `LeadCaptureFieldConfig`
- `src/ui/forms/lead-capture-form.test.ts` — new

## Test plan

- [x] `npm test` — **147 passed (141 prior + 6 new)**
- [x] `npm run build` — clean, 135.36 kB / 41.85 kB gzipped (no size regression vs prior bundle)
- [ ] Manual smoke: rebuild widget, open `/agents/1` in the dashboard, reorder fields, confirm the live preview reflects the new order on re-init

## Rollout

This is on the CDN `@v3` semver. Once merged, **kick `release.yml`** with a patch bump (e.g. `v3.0.14`) so the dashboard previews and `containerone.net` widget pick it up automatically — jsDelivr resolves `@v3` to the highest tagged 3.x.

For local testing before release: build locally (`npm run build`) and set `NEXT_PUBLIC_CHAT_EMBED_OVERRIDE=http://localhost:8080/dist/chat-embed.js` on the dashboard preview env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)