### PR TITLE
MMX-598: rename widget config to memoxPosthogApiKey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Key design choices:
 - **Shadow DOM** — widget renders inside a shadow root so host-page CSS cannot bleed in.
 - **WebSocket** — persistent connection to memox-hub for real-time chat and streaming.
 - **Markdown rendering** — `marked` + `DOMPurify` (both bundled; DOMPurify sanitizes before DOM insertion).
-- **PostHog** — no SDK; events posted directly to `/capture/` via `fetch` with `keepalive: true`. No-op when `posthogApiKey` is unset.
+- **PostHog** — no SDK; events posted directly to `/capture/` via `fetch` with `keepalive: true`. No-op when `memoxPosthogApiKey` is unset (the field is server-injected via memox-hub's /embed/init from a POSTHOG_PROJECT_API_KEY env var; namespaced under `memox` so customers can keep using their own `posthogApiKey` for their own analytics without collision).
 
 ## Embed Config
 
@@ -117,7 +117,7 @@ Key config fields (`ChatEmbedConfig` in `src/config/types.ts`):
 | `agent_id` | Agent ID |
 | `mode` | `'floating'` (default) or `'inline'` |
 | `storageNamespace` | localStorage prefix — set a unique value when multiple widgets share an origin |
-| `posthogApiKey` | PostHog project key — omit to disable analytics |
+| `memoxPosthogApiKey` | Memox-owned PostHog key (server-injected). Customers' own `posthogApiKey` is NOT read by the widget — set this only for self-hosted / OSS deploys without a Memox backend. |
 | `posthogHost` | PostHog host (default: `https://us.i.posthog.com`) |
 | `theme` | Full theme object (colors, fonts, dimensions) |
 | `leadCapture` | Show lead form before chat starts (default: `true`) |

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -317,14 +317,19 @@ export interface ChatEmbedConfig {
    */
   apiBase?: string;
   /**
-   * PostHog project API key. When unset, all analytics calls are no-ops
-   * — self-hosted/OSS deployments don't need PostHog.
+   * Memox-owned PostHog project key for widget analytics. Injected by
+   * memox-hub's /embed/init response as ``memox_posthog_api_key`` and
+   * auto-aliased to camelCase by normalizeServerConfig. Namespaced under
+   * ``memox`` so customers who set their own ``posthogApiKey`` for THEIR
+   * own analytics aren't accidentally overridden by mergeConfig precedence
+   * (see merge.ts:20-22 — server wins on truthy values). MMX-598.
+   * When unset, all analytics calls are no-ops — self-hosted/OSS deployments
+   * don't need PostHog.
    */
-  posthogApiKey?: string | null;
-  /**
-   * PostHog host (defaults to https://us.i.posthog.com).
-   */
-  posthogHost?: string;
+  memoxPosthogApiKey?: string | null;
+
+  /** Optional override of PostHog ingest host (e.g. EU region). Defaults to https://us.i.posthog.com. */
+  memoxPosthogHost?: string;
   /**
    * Launcher form-factor + attractor system. Snake_case matches the
    * /embed/init wire format so server-fetched values can be merged in

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -326,7 +326,7 @@ export interface ChatEmbedConfig {
    * When unset, all analytics calls are no-ops — self-hosted/OSS deployments
    * don't need PostHog.
    */
-  memoxPosthogApiKey?: string | null;
+  memoxPosthogApiKey?: string;
 
   /** Optional override of PostHog ingest host (e.g. EU region). Defaults to https://us.i.posthog.com. */
   memoxPosthogHost?: string;

--- a/src/connection/embed-config-listener.ts
+++ b/src/connection/embed-config-listener.ts
@@ -27,6 +27,11 @@ interface EmbedConfigUpdatePayload {
     lead_capture?: { enabled?: boolean; mandatory?: boolean };
     quick_questions?: string[];
     attractor_variant?: string;
+    // Posthog fields ride the broadcast for completeness — analytics.init
+    // is NOT re-called on update, so a runtime key rotation requires a
+    // page refresh to take effect. MMX-598.
+    memox_posthog_api_key?: string;
+    memox_posthog_host?: string;
   };
 }
 

--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -164,4 +164,13 @@ describe('normalizeServerConfig — theme snake→camel bridge', () => {
     // Array passes through untouched — guards against future bad payloads.
     expect(Array.isArray(out.theme)).toBe(true);
   });
+
+  it('aliases memox_posthog_api_key / memox_posthog_host to camelCase (MMX-598)', () => {
+    const out = normalizeServerConfig({
+      memox_posthog_api_key: 'phc_x',
+      memox_posthog_host: 'https://eu.i.posthog.com',
+    });
+    expect(out.memoxPosthogApiKey).toBe('phc_x');
+    expect(out.memoxPosthogHost).toBe('https://eu.i.posthog.com');
+  });
 });

--- a/src/index.init-timeout.test.ts
+++ b/src/index.init-timeout.test.ts
@@ -99,7 +99,7 @@ vi.mock('./ui/shadow-host', () => ({
 // Enable leadCapture so showLeadForm() is triggered.
 window.MemoxChatConfig = {
   embedId: 'emb_timeout_test',
-  posthogApiKey: 'phc_test',
+  memoxPosthogApiKey: 'phc_test',
   leadCapture: true,
 } as unknown as typeof window.MemoxChatConfig;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,7 +60,7 @@ function flushAsync(): Promise<void> {
 // vi.mock is hoisted, but window globals are not — so we set them here at module scope.
 window.MemoxChatConfig = {
   embedId: 'emb_test',
-  posthogApiKey: 'phc_test',
+  memoxPosthogApiKey: 'phc_test',
   // Disable lead capture so maybeShowLeadCapture goes through the anonymous-visitor
   // path, avoiding the form UI which needs additional DOM scaffolding.
   leadCapture: false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -100,3 +100,46 @@ describe('index bootstrap — chat_widget_loaded analytics contract', () => {
     expect(initOrder).toBeLessThan(loadedOrder!);
   });
 });
+
+// ── MMX-598: Memox-namespaced PostHog config rename ───────────────────────────
+
+describe('widget reads memox-namespaced PostHog config (MMX-598)', () => {
+  beforeEach(() => {
+    analyticsInitSpy.mockClear();
+    captureSpy.mockClear();
+  });
+
+  it('passes memoxPosthogApiKey from config into analytics.init', async () => {
+    (window as any).MemoxChatConfig = {
+      embedId: undefined,
+      memoxPosthogApiKey: 'phc_test_memox_key',
+      memoxPosthogHost: 'https://us.i.posthog.com',
+      leadCapture: false,
+    };
+
+    vi.resetModules();
+    await import('./index');
+    await flushAsync();
+
+    expect(analyticsInitSpy).toHaveBeenCalled();
+    const callArg = analyticsInitSpy.mock.calls[0][0];
+    expect(callArg.apiKey).toBe('phc_test_memox_key');
+    expect(callArg.host).toBe('https://us.i.posthog.com');
+  });
+
+  it('ignores legacy posthogApiKey field (does not read it for Memox events)', async () => {
+    (window as any).MemoxChatConfig = {
+      embedId: undefined,
+      posthogApiKey: 'phc_customer_owned_must_not_leak',
+      leadCapture: false,
+    };
+
+    vi.resetModules();
+    await import('./index');
+    await flushAsync();
+
+    expect(analyticsInitSpy).toHaveBeenCalled();
+    const callArg = analyticsInitSpy.mock.calls[0][0];
+    expect(callArg.apiKey).toBeUndefined();
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -105,6 +105,7 @@ describe('index bootstrap — chat_widget_loaded analytics contract', () => {
 
 describe('widget reads memox-namespaced PostHog config (MMX-598)', () => {
   beforeEach(() => {
+    vi.resetModules();
     analyticsInitSpy.mockClear();
     captureSpy.mockClear();
   });
@@ -117,7 +118,6 @@ describe('widget reads memox-namespaced PostHog config (MMX-598)', () => {
       leadCapture: false,
     };
 
-    vi.resetModules();
     await import('./index');
     await flushAsync();
 
@@ -134,7 +134,6 @@ describe('widget reads memox-namespaced PostHog config (MMX-598)', () => {
       leadCapture: false,
     };
 
-    vi.resetModules();
     await import('./index');
     await flushAsync();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,14 @@ async function init(): Promise<void> {
   // sessionStore reads/writes so multiple widgets on the same origin
   // (marketing site widget + per-persona demo embed) don't share state.
   sessionStore.setNamespace(config.storageNamespace);
-  // Wire PostHog analytics (no-op when ``posthogApiKey`` is unset).
+  // Wire PostHog analytics (no-op when ``memoxPosthogApiKey`` is unset).
   // attractor_variant is read from the server's init response so every event
   // can be split by launcher variant in PostHog funnels.
   // ``chat_widget_loaded`` is captured at the end of init() instead of here
   // to ensure the event reflects a successfully bootstrapped widget.
   analytics.init({
-    apiKey: config.posthogApiKey,
-    host: config.posthogHost,
+    apiKey: config.memoxPosthogApiKey,
+    host: config.memoxPosthogHost,
     orgId: config.org_id ?? null,
     agentId: config.agent_id ?? null,
     attractorVariant: (serverConfig as Record<string, unknown>).attractor_variant as string | null | undefined,


### PR DESCRIPTION
## Summary
- Renames the widget config field from `posthogApiKey` → `memoxPosthogApiKey` (and `posthogHost` → `memoxPosthogHost`).
- Reason: memox-hub will start injecting Memox's PostHog project key via `/embed/init`. The default `mergeConfig` precedence (`src/config/merge.ts:20` — server wins on truthy values) would otherwise overwrite any customer-set `posthogApiKey`. Namespacing under `memox` makes collision impossible.

## Why
Today the widget reads `config.posthogApiKey` but no path actually sets it — customer snippets don't, embed/init doesn't, defaults don't. All `analytics.capture()` calls silently no-op. The fix lands across two PRs:
- **This PR**: rename the widget-side field so we don't collide with any future customer-set `posthogApiKey`.
- **Companion memox-hub PR**: https://github.com/Memox-Inc/memox-hub/pull/386 (injects `memox_posthog_api_key` into `/embed/init` from a `POSTHOG_PROJECT_API_KEY` env var).

## What changes
- `src/config/types.ts`: rename two fields on `ChatEmbedConfig`; JSDoc explains the collision rationale. `| null` union dropped (was unused).
- `src/index.ts`: `analytics.init({...})` now reads `config.memoxPosthogApiKey` / `config.memoxPosthogHost`.
- `src/index.test.ts`: two new tests pin the rename — positive case (new field flows through) + negative case (legacy `posthogApiKey` is NOT read for Memox events).
- `src/connection/init.test.ts`: pinned test for `normalizeServerConfig` snake→camel alias of `memox_posthog_api_key` / `memox_posthog_host` (prevents future-refactor regression).
- `src/connection/embed-config-listener.ts`: `EmbedConfigUpdatePayload` type extended to include the new posthog fields (broadcast frame contract).
- `src/index.test.ts` + `src/index.init-timeout.test.ts`: stale fixture references renamed.
- `CLAUDE.md`: PostHog field documentation updated.

## What you need to do — checklist

### Pre-merge
- [ ] Skim the rename — confirm `posthogApiKey` is fully retired in production code paths (negative test asserts this).
- [ ] Confirm CI green (vitest 163/163, `tsc --noEmit` clean).

### Merge this PR FIRST (before the memox-hub companion PR)
- [ ] Squash-merge or merge-commit (your call). Per workspace CLAUDE.md, only you merge.

### Immediately after merge — tag and release v3.0.15
- [ ] `cd repos/ChatEmbed_V2 && git checkout main && git pull --ff-only`
- [ ] Trigger the release workflow:
  ```bash
  gh workflow run release.yml -f version=3.0.15 -f set_active=true
  ```
- [ ] Wait for the workflow to complete (~2-3 min). Verify the new tag is live on jsDelivr:
  ```bash
  curl -sI "https://cdn.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v3/dist/chat-embed.js" | grep x-jsd-version
  ```
  Expected: `x-jsd-version: 3.0.15` (may take a few minutes — retry if you still see `3.0.14`).
- [ ] Optionally accelerate jsDelivr cache turnover for the `@v3` ref:
  ```bash
  curl "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v3/dist/chat-embed.js"
  ```

### After companion memox-hub PR is merged — E2E browser smoke
- [ ] Hard-reload containerone.net (or any embedded customer page). DevTools Network → filter `i.posthog.com` → should see opaque POSTs to `/capture/` within ~1s of widget render.
- [ ] Open Live Events in the Memox PostHog project → filter `event = chat_widget_loaded AND properties.$current_url ~ containerone.net` → fresh events should arrive within 5-30 min.
- [ ] **Override-isolation check** (the whole point of the rename): in DevTools, set `window.MemoxChatConfig.posthogApiKey = "phc_FAKE_CUSTOMER_KEY"` BEFORE the widget bootstraps. Then inspect the `/capture/` POST body — `api_key` should be Memox's real key, NOT `phc_FAKE_CUSTOMER_KEY`. If the fake key leaks, the rename didn't take effect.

## Rollback path
- If v3.0.15 has any issue, jsDelivr's `@v3` resolves to the latest semver — re-tag `v3.0.16` with a revert if needed. Customers pinned to `@v3.0.14` are unaffected (they have current broken-analytics state, which is unchanged).

## Test plan
- [x] New unit tests assert widget reads `memoxPosthogApiKey` and explicitly does NOT read legacy `posthogApiKey`.
- [x] `normalizeServerConfig` snake→camel alias pinned for `memox_posthog_*` fields.
- [x] Full vitest suite green (163/163).
- [x] `tsc --noEmit` clean.

## Out of scope (follow-up tickets)
- Django system check that warns at startup when `POSTHOG_PROJECT_API_KEY=""` in prod (closes the "forgot to set env var = silent flat funnel for a week" failure mode).
- Widget-side `console.warn` when a customer's legacy `posthogApiKey` is detected on `MemoxChatConfig` (helps customers debug their own analytics post-rename).
- WS broadcast `analytics.init` re-call for live key rotations (key rotation is rare; for now requires page reload).
- `/embed/init/` rate limiting (pre-existing concern, separate hardening ticket).
- Filtering `memox_*` fields out of the `embed-config-listener.ts:78` `console.log` frame (PostHog keys are public-safe but it's noise).

## Plan
See: `docs/superpowers/plans/2026-05-15-posthog-key-via-embed-init.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
