### PR TITLE
MMX-597: send X-Org-Id header so post-handover visitor session survives

### DIFF
--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -6,6 +6,13 @@ function buildHeaders(config: ChatEmbedConfig): Record<string, string> {
     'Content-Type': 'application/json',
     Authorization: `Token ${config.token} `,
   };
+  // X-Org-Id is required for the backend's RBAC / org-scoping middleware.
+  // Without it, ChatSessionViewSet.get_queryset falls back to for_user(None)
+  // which yields an empty queryset and a 404 on the detail endpoint —
+  // causing the chatID-drift cascade tracked in MMX-597.
+  if (config.org_id !== undefined && config.org_id !== null) {
+    headers['X-Org-Id'] = String(config.org_id);
+  }
   if (config.isMobileDevice) {
     headers['X-App-Platform'] = 'react-native-webview';
   }


### PR DESCRIPTION
## Summary

Two related dogfood bugs reported during MMX-275 mobile V1 testing:

1. After a handover, the visitor's playground widget would stop receiving rep replies (sent from mobile or web).
2. The widget would silently mint a fresh chatID, creating a brand-new chat session orphaned from the original.

Root cause: the widget's REST helper (`api-client.ts` → `buildHeaders`) was sending `Authorization` but **not** `X-Org-Id`. The backend's `ChatSessionViewSet.get_queryset` (memox-hub `chat_app/api/v1/viewsets/sessions.py:23-61`) needs org context — from `?organization_id=` query param OR the `X-Org-Id` header (populated by `OrgTeamContextMiddleware` into `request.org_id`). Without it, the scope is empty and the detail endpoint 404s on a session that very much exists.

`validateSession` treats that 404 as "orphaned" and instructs the embed to mint a fresh chatID. Result on the next reconnect: backend creates a new session for the new chatID, and the visitor's widget now belongs to a different room than the rep's WS. Visitor never sees rep replies; rep never sees visitor replies.

Diagnosis was confirmed by the user's incognito repro: with no auth token, `validateSession` short-circuits at the `!token` check, the GET request never fires, and the visitor session survives handover intact. Authenticated session needed the same survival — which this PR provides by including `X-Org-Id`.

## Change

`src/connection/api-client.ts` — append `X-Org-Id: ${config.org_id}` to the headers built by `buildHeaders`. `org_id` is already part of `ChatEmbedConfig` (line 252 of `config/types.ts`), so consumers don't need to update their config.

7 lines including the doc comment.

## Test plan

- [x] `npx tsc --noEmit` clean (0 errors).
- [x] `npm run build` succeeds; bundle size unchanged (~150KB).
- [ ] Manual: reload the playground in normal browser, exchange a few messages, trigger handover, accept on dashboard. Verify the visitor's `chatID` is preserved across reconnects (check Network tab: same `room_name` UUID in successive WS connect URLs).
- [ ] Manual: messages sent from mobile/web rep AFTER handover now appear in the visitor's playground (previously dropped due to room mismatch).

## Out of scope

- A separate dashboard-side bug (`ChatInputField` disable check uses `(props.assignedUser?.id ?? props.assignedUser) === userId` which fails when `assignedUser` is an object/undefined — disables the input even after handover accept). File and fix in `mmx-unified-chat` separately. Confirmed by user that this is also blocking on web, but doesn't repro in incognito because the user isn't acting as both visitor + agent in same session.
- Defensive backend hardening (make `for_user(None)` fall back to user-accessible orgs) — separate concern; this PR fixes the immediate root cause.
- Doesn't change `dist/chat-embed.js` — the release.yml workflow regenerates it on tag, per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)