### PR TITLE
MMX-599: chat base analytics — widget

### DIFF
--- a/src/analytics/embed-events.test.ts
+++ b/src/analytics/embed-events.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { postEmbedEvent } from './embed-events';
+
+describe('postEmbedEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts chat_opened with embed_id, distinct_id, metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postEmbedEvent({
+      baseUrl: 'https://hub.memox.io/api/v1/',
+      embedId: 'emb_abc',
+      eventType: 'chat_opened',
+      distinctId: 'anon_123',
+      metadata: { trigger: 'manual' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://hub.memox.io/api/v1/embed/events/');
+    expect(opts.method).toBe('POST');
+    expect(opts.keepalive).toBe(true);
+    expect(JSON.parse(opts.body as string)).toEqual({
+      embed_id: 'emb_abc',
+      event_type: 'chat_opened',
+      distinct_id: 'anon_123',
+      metadata: { trigger: 'manual' },
+    });
+  });
+
+  it('posts form_submitted with visitor_id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await postEmbedEvent({
+      baseUrl: 'https://hub.memox.io/api/v1/',
+      embedId: 'emb_abc',
+      eventType: 'form_submitted',
+      distinctId: 'anon_123',
+      visitorId: 42,
+    });
+
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(JSON.parse(opts.body as string)).toMatchObject({
+      embed_id: 'emb_abc',
+      event_type: 'form_submitted',
+      visitor_id: 42,
+    });
+  });
+
+  it('never throws on fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    await expect(
+      postEmbedEvent({
+        baseUrl: 'https://hub.memox.io/api/v1/',
+        embedId: 'emb_abc',
+        eventType: 'chat_opened',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/analytics/embed-events.ts
+++ b/src/analytics/embed-events.ts
@@ -1,0 +1,36 @@
+// Posts a single analytics event to memox-hub. Fire-and-forget, never
+// blocks the widget. Mirrors the PostHog capture call's resilience —
+// any failure is swallowed.
+
+export type EmbedEventType = 'chat_opened' | 'form_submitted';
+
+export interface PostEmbedEventOptions {
+  baseUrl: string;
+  embedId: string;
+  eventType: EmbedEventType;
+  distinctId?: string;
+  visitorId?: number | null;
+  metadata?: Record<string, unknown>;
+}
+
+export async function postEmbedEvent(opts: PostEmbedEventOptions): Promise<void> {
+  try {
+    const url = `${opts.baseUrl.replace(/\/$/, '')}/embed/events/`;
+    const body: Record<string, unknown> = {
+      embed_id: opts.embedId,
+      event_type: opts.eventType,
+    };
+    if (opts.distinctId) body.distinct_id = opts.distinctId;
+    if (opts.visitorId != null) body.visitor_id = opts.visitorId;
+    if (opts.metadata) body.metadata = opts.metadata;
+
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      keepalive: true,
+    });
+  } catch {
+    // swallow; analytics must never break the widget
+  }
+}

--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -67,6 +67,7 @@ export async function createVisitor(
   phone: string | null,
   zip: string | null,
   config: ChatEmbedConfig,
+  customFields?: Record<string, string>,
 ): Promise<VisitorInfo> {
   try {
     const baseUrl = config.baseUrl;
@@ -98,13 +99,17 @@ export async function createVisitor(
 
     if (getJson.detail === 'Not found.' || !getJson.results?.length) {
       // Create new visitor
+      const metadata: Record<string, unknown> = { anonymous: isAnonymous };
+      if (customFields && Object.keys(customFields).length > 0) {
+        Object.assign(metadata, customFields);
+      }
       const visitorPayload = {
         name: visitorName,
         email: visitorEmail,
         phone_number: phone || '',
         zip_code: zip || '',
         organization: config.org_id,
-        metadata: { anonymous: isAnonymous },
+        metadata,
       };
 
       const postResponse = await fetch(`${baseUrl}visitors/`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -835,12 +835,19 @@ async function init(): Promise<void> {
           has_zip: !!lead.zip,
         });
 
+        // Collect custom fields (f_<nanoid> keys) from lead.values so
+        // they flow through to Visitor.metadata on the backend.
+        const customFields: Record<string, string> = {};
+        for (const [k, v] of Object.entries(lead.values ?? {})) {
+          if (k.startsWith('f_')) customFields[k] = v;
+        }
         visitorInfo = await createVisitor(
           sanitizeInput(lead.name),
           sanitizeInput(lead.email),
           lead.phone,
           sanitizeInput(lead.zip),
           config,
+          Object.keys(customFields).length > 0 ? customFields : undefined,
         );
         sessionStore.updateSession({ visitorInfo });
         void postEmbedEvent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { pickPrimaryAttractor } from './ui/attractors/pick-primary';
 import { createOpenTriggerStore } from './ui/open-trigger';
 import { normalizePhoneE164 } from './ui/forms/validation';
 import * as analytics from './analytics/posthog';
+import { postEmbedEvent } from './analytics/embed-events';
+import { getOrCreateDistinctId } from './utils/distinct-id';
 import { fetchInitConfig, normalizeServerConfig } from './connection/init';
 import { applyTheme } from './ui/theme-vars';
 import { startEmbedConfigListener } from './connection/embed-config-listener';
@@ -725,6 +727,13 @@ async function init(): Promise<void> {
       // later when the time threshold finally elapses.
       if (trigger !== 'auto_open') autoOpenHandle?.notifyManualOpen();
       analytics.capture('chat_opened', trigger ? { trigger } : undefined);
+      void postEmbedEvent({
+        baseUrl: config.baseUrl ?? '',
+        embedId: config.embedId ?? '',
+        eventType: 'chat_opened',
+        distinctId: getOrCreateDistinctId(),
+        metadata: trigger ? { trigger } : undefined,
+      });
       widget.style.display = 'flex';
       widget.classList.add('mcx-widget--open');
       widget.classList.remove('mcx-widget--closing');

--- a/src/index.ts
+++ b/src/index.ts
@@ -843,6 +843,13 @@ async function init(): Promise<void> {
           config,
         );
         sessionStore.updateSession({ visitorInfo });
+        void postEmbedEvent({
+          baseUrl: config.baseUrl ?? '',
+          embedId: config.embedId ?? '',
+          eventType: 'form_submitted',
+          distinctId: getOrCreateDistinctId(),
+          visitorId: typeof visitorInfo?.id === 'number' ? visitorInfo.id : null,
+        });
       }
 
       // Show input but keep disabled until WS connects


### PR DESCRIPTION
## Summary

Widget changes for [MMX-599 Chat Base Analytics](https://memox.atlassian.net/browse/MMX-599). Fires two server-side analytics events to memox-hub and plumbs custom lead-form fields into `Visitor.metadata`.

- **`postEmbedEvent` helper** (`src/analytics/embed-events.ts`) — fire-and-forget POST to `/api/v1/embed/events/`. Mirrors PostHog capture's resilience (swallows all failures, never blocks the widget). `keepalive: true` so events survive page unload.
- **`chat_opened` event** fired when the visitor clicks the launcher. Passes `trigger` in metadata when present. Sits AFTER the existing PostHog capture call so PostHog behavior is unchanged.
- **`form_submitted` event** fired after `createVisitor` resolves successfully. Passes `visitor_id` so the backend can join to the Visitor row. Guards on `typeof visitorInfo.id === 'number'` to skip the offline-fallback string-ID case.
- **Custom lead-form fields** (keys like `f_<nanoid>`) now flow through `createVisitor` → request body `metadata` → `Visitor.metadata` JSONField. Extracted at the call site from `LeadData.values`, which is already keyed by `field.key` (no changes to the form component itself).
- **`dist/chat-embed.js` rebuilt** — 150.86 kB IIFE bundle.

Backend PR (depends on): https://github.com/Memox-Inc/memox-hub/pull/387
Spec: `docs/superpowers/specs/2026-05-16-chat-base-analytics-design.md`
Plan: `docs/superpowers/plans/2026-05-16-chat-base-analytics.md`

## Test plan
- [x] `npm test` — 166/166 pass (19 test files), including 3 new `embed-events.test.ts` tests
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — produces a 150.86 kB single-file IIFE bundle
- [ ] Manual smoke: load the widget against a memox-hub running PR #387, click launcher, submit form, verify `ChatAnalyticsEvent` rows appear in DB

## Deviations from plan (all justified, called out in implementation)
- `form_submitted` placed after `await createVisitor(...)` (not just after `analytics.capture`) so `visitorId` is actually available.
- `lead-capture-form.ts` unchanged — `LeadData.values` already carries every field's value keyed by `field.key`, so custom-field extraction lives at the `createVisitor` call site instead of inside the form component.
- `embedId` was already on `ChatEmbedConfig` (added in a prior ticket), so no type change needed.

## Out of scope
- Frontend dashboard changes (analytics tab + form submissions tab) — `mmx-unified-chat` PR coming next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)