### PR TITLE
MMX-611: widget prefers EmbedToken session auth from /embed/init/

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -249,6 +249,18 @@ export interface ChatEmbedConfig {
   socketUrl?: string;
   baseUrl?: string;
   token?: string;
+  /**
+   * Per-session embed token issued by ``POST /api/v1/embed/init/``.
+   * When present, REST calls send ``Authorization: EmbedToken <sessionToken>``
+   * instead of the legacy global ``Token <token>`` — which is org-scoped
+   * server-side via the embed config, so a leaked widget bundle can only
+   * see/modify visitors in its own org. Falls back to the legacy
+   * ``token`` if the server omits it (older backend, OSS deploys).
+   *
+   * Phase B PR3 of the embed-token-leak fix will drop ``token`` from
+   * the init response, making this the only auth path.
+   */
+  sessionToken?: string;
   org_id?: string | number;
   agent_id?: string;
   welcomeMessage?: string | null;

--- a/src/connection/api-client.test.ts
+++ b/src/connection/api-client.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVisitor, validateSession } from './api-client';
+
+// MMX-611: assert the widget sends ``Authorization: EmbedToken …`` when a
+// per-session token is configured, and falls back to legacy ``Token …``
+// otherwise. The header switch is the core of the embed-token-leak fix.
+
+const baseConfig = {
+  baseUrl: 'https://hub.memox.io/api/v1/',
+  org_id: 9,
+};
+
+function getLastRequestInit(fetchMock: ReturnType<typeof vi.fn>): RequestInit {
+  const calls = fetchMock.mock.calls;
+  return calls[calls.length - 1][1] as RequestInit;
+}
+
+function getAuthHeader(init: RequestInit): string | undefined {
+  return (init.headers as Record<string, string>).Authorization;
+}
+
+describe('api-client Authorization header (MMX-611)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends EmbedToken when sessionToken is set', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 'open' }), { status: 200 }));
+    await validateSession('chat-id-1', { ...baseConfig, sessionToken: 'per-session-abc' });
+    expect(getAuthHeader(getLastRequestInit(fetchMock))).toBe('EmbedToken per-session-abc');
+  });
+
+  it('falls back to legacy Token when only the legacy token is set', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 'open' }), { status: 200 }));
+    await validateSession('chat-id-1', { ...baseConfig, token: 'legacy-global-token' });
+    expect(getAuthHeader(getLastRequestInit(fetchMock))).toBe('Token legacy-global-token');
+  });
+
+  it('prefers sessionToken over legacy token when both are present', async () => {
+    // Real-world: during Phase B transition the server returns both. The
+    // widget must pick the session-scoped one so requests are org-bounded.
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: 'open' }), { status: 200 }));
+    await validateSession('chat-id-1', {
+      ...baseConfig,
+      sessionToken: 'per-session-abc',
+      token: 'legacy-global-token',
+    });
+    expect(getAuthHeader(getLastRequestInit(fetchMock))).toBe('EmbedToken per-session-abc');
+  });
+
+  it('createVisitor uses EmbedToken header on the POST request', async () => {
+    // First call: GET ?email=… returns no results so the path takes the POST branch.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [] }), { status: 200 }),
+    );
+    // POST returns a created visitor.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 42, name: 'Test User' }), { status: 201 }),
+    );
+
+    const result = await createVisitor('Test User', 'test@example.com', null, null, {
+      ...baseConfig,
+      sessionToken: 'per-session-abc',
+    });
+
+    expect(result.id).toBe(42);
+    // Both the GET lookup and the POST create must carry the EmbedToken.
+    expect(getAuthHeader(fetchMock.mock.calls[0][1] as RequestInit)).toBe(
+      'EmbedToken per-session-abc',
+    );
+    expect(getAuthHeader(fetchMock.mock.calls[1][1] as RequestInit)).toBe(
+      'EmbedToken per-session-abc',
+    );
+  });
+
+  it('createVisitor throws when neither sessionToken nor token is configured', async () => {
+    // Hits the offline-fallback catch and returns an offline placeholder
+    // rather than rejecting — preserves existing "fail-open" UX.
+    const result = await createVisitor('Test User', null, null, null, { ...baseConfig });
+    expect(result.id).toMatch(/^offline_/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -2,9 +2,19 @@ import type { ChatEmbedConfig, VisitorInfo } from '../config/types';
 import { collectBrowserMetadata, createAnonymousEmail } from './browser-metadata';
 
 function buildHeaders(config: ChatEmbedConfig): Record<string, string> {
+  // Prefer the per-session embed token (EmbedTokenAuthentication on the
+  // backend, org-scoped via embed config) over the legacy global
+  // ``Token`` (a superuser key publicly returned by /embed/init/ that we
+  // are killing in Phase B PR3 of MMX-227). The fallback exists for two
+  // cases: (a) an older backend that does not yet ship ``session_token``
+  // in the init response, (b) OSS / self-hosted deploys without the
+  // embed-init handshake.
+  const authHeader = config.sessionToken
+    ? `EmbedToken ${config.sessionToken}`
+    : `Token ${config.token ?? ''}`;
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    Authorization: `Token ${config.token} `,
+    Authorization: authHeader,
   };
   if (config.isMobileDevice) {
     headers['X-App-Platform'] = 'react-native-webview';
@@ -15,6 +25,10 @@ function buildHeaders(config: ChatEmbedConfig): Record<string, string> {
   return headers;
 }
 
+function hasAuthCredentials(config: ChatEmbedConfig): boolean {
+  return Boolean(config.sessionToken || config.token);
+}
+
 export type SessionValidation = 'valid' | 'closed' | 'orphaned';
 
 export async function validateSession(
@@ -23,8 +37,7 @@ export async function validateSession(
 ): Promise<SessionValidation> {
   try {
     const baseUrl = config.baseUrl;
-    const token = config.token;
-    if (!baseUrl || !token || !sessionChatID) return 'valid';
+    if (!baseUrl || !hasAuthCredentials(config) || !sessionChatID) return 'valid';
 
     const response = await fetch(`${baseUrl}sessions/${sessionChatID}/`, {
       method: 'GET',
@@ -57,10 +70,9 @@ export async function createVisitor(
 ): Promise<VisitorInfo> {
   try {
     const baseUrl = config.baseUrl;
-    const token = config.token;
 
-    if (!baseUrl || !token) {
-      throw new Error('Missing required configuration: baseUrl and token');
+    if (!baseUrl || !hasAuthCredentials(config)) {
+      throw new Error('Missing required configuration: baseUrl and (sessionToken or token)');
     }
 
     const isAnonymous = !email;

--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -71,6 +71,25 @@ describe('fetchInitConfig', () => {
     expect(body2.distinct_id).toBe(firstId);
   });
 
+  it('exposes session_token from server response as runtime.sessionToken (MMX-611)', async () => {
+    // The widget should prefer the per-session embed token over the
+    // legacy global token. Both arrive on the same /embed/init/ response
+    // during the Phase B transition; PR3 will drop the legacy field.
+    const mockResponse = {
+      embed_id: 'emb_x',
+      token: 'legacy-global-token',
+      session_token: 'per-session-abc123',
+      config: {},
+    };
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(mockResponse), { status: 200 }));
+
+    const result = await fetchInitConfig('emb_x', 'https://api.memox.io');
+    expect(result.sessionToken).toBe('per-session-abc123');
+    // Legacy token remains exposed so the fallback path keeps working
+    // until PR3 strips it server-side. buildHeaders picks the right one.
+    expect(result.token).toBe('legacy-global-token');
+  });
+
   it('strips trailing slash from apiBase', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ embed_id: 'emb', config: {} }), { status: 200 }),

--- a/src/connection/init.ts
+++ b/src/connection/init.ts
@@ -66,6 +66,12 @@ export async function fetchInitConfig(
     // ``normalizeServerConfig`` exactly as before.
     const runtime: Record<string, any> = {};
     if (typeof data.token === 'string' && data.token) runtime.token = data.token;
+    // Per-session embed token — preferred over the legacy global token.
+    // Carries the embed config server-side, so REST calls under this auth
+    // are org-scoped. See ChatEmbedConfig.sessionToken for details.
+    if (typeof data.session_token === 'string' && data.session_token) {
+      runtime.sessionToken = data.session_token;
+    }
     if (typeof data.base_url === 'string' && data.base_url) runtime.baseUrl = data.base_url;
     if (typeof data.socket_url === 'string' && data.socket_url) runtime.socketUrl = data.socket_url;
     if (data.org_id !== undefined && data.org_id !== null) runtime.org_id = String(data.org_id);


### PR DESCRIPTION
## Summary

Phase B PR2 of the embed-token-leak fix (epic [MMX-227](https://memox.atlassian.net/browse/MMX-227)). PR1 ([MMX-600](https://memox.atlassian.net/browse/MMX-600), memox-hub#388) wired `EmbedTokenAuthentication` into `VisitorViewSet` behind a backwards-compatible auth chain. This PR switches the V3 widget bundle to actually send the session token so REST calls become org-scoped instead of riding the public superuser `Token` returned today by `/embed/init/`.

- `src/connection/init.ts` — pull `data.session_token` off the `/embed/init/` response, expose as `runtime.sessionToken`. Legacy `data.token` is still read for the fallback.
- `src/config/types.ts` — add `sessionToken?: string` with doc-comment.
- `src/connection/api-client.ts` — `buildHeaders` prefers `Authorization: EmbedToken <sessionToken>` and falls back to `Token <token>`. `validateSession` / `createVisitor` short-circuits accept either credential. Trailing-space bug on the legacy `Token` header fixed as drive-by.

WebSocket path is intentionally unchanged — V3 widget never sends a token over WS today.

## Test plan

Automated (all green locally — 169/169 tests):
- [x] `npm test -- --run` — full vitest suite passes including new tests.
- [x] `npx tsc --noEmit` — typecheck clean.
- [x] `npm run build` — IIFE bundle builds (150 KB / 45 KB gzip, unchanged).

New tests:
- [x] `init.test.ts` — server `session_token` exposed as `sessionToken`; legacy `token` still present.
- [x] `api-client.test.ts` (new file, 5 tests) — EmbedToken when set, legacy fallback, preference when both, EmbedToken on GET + POST in `createVisitor`, offline-fallback when no credential.

Post-merge release validation (deferred to release ticket):
- [ ] Cut v3.0.15 via `release.yml` (`set_active=true`).
- [ ] Bump `NEXT_PUBLIC_CHAT_EMBED_OVERRIDE` on website + mmx-unified-chat to `@v3.0.15`.
- [ ] Load widget on `localhost:3002/demo/outbound-sales`, confirm `Authorization: EmbedToken …` on visitor REST calls in DevTools Network tab.
- [ ] Browser-console cross-tenant attack: `fetch('/api/v1/visitors/', { method: 'POST', headers: {…}, body: JSON.stringify({ organization: <other-org>, email: 'x@y' }) })` — server pins org from token, payload override is ignored.
- [ ] After 24h+ of clean prod traffic, schedule Phase B PR3 to drop the legacy `Token` path entirely.

## Out of scope

- Removing the legacy `token` field from `/embed/init/` response (Phase B PR3).
- Removing `NEXT_PUBLIC_CHAT_EMBED_TOKEN` env var on website + mmx-unified-chat (Phase B PR3).
- Deleting the `embed-service` superuser (Phase B PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MMX-227]: https://memox.atlassian.net/browse/MMX-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMX-600]: https://memox.atlassian.net/browse/MMX-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ