### PR TITLE
MMX-551: render the sales rep's profile photo in the chat embed avatar

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -359,6 +359,11 @@ export interface StoredMessage {
   isStreaming?: boolean;
   messageId?: string;
   senderName?: string | { name?: string };
+  // MMX-551: backend serves a freshly-signed R2/S3 URL for the sales
+  // rep's profile photo on handover_message and post-handover text
+  // frames. When present we render it as the sales-rep avatar `<img>`
+  // overlay; absent / empty falls back to the default colored circle.
+  senderPhotoUrl?: string;
   created_at?: string;
   lastChunkTime?: number;
 }

--- a/src/connection/websocket-manager.ts
+++ b/src/connection/websocket-manager.ts
@@ -14,6 +14,10 @@ export interface WsMessageData {
   is_complete?: boolean;
   created_at?: string;
   sender_name?: string;
+  // MMX-551: signed R2 / S3 URL for the sales rep's profile photo,
+  // shipped on handover_message and post-handover text frames. Empty
+  // string = no photo set, fall back to the default avatar icon.
+  sender_photo_url?: string;
   assigned_user_name?: string;
   assigned_user_email?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,11 @@ async function init(): Promise<void> {
   let visitorInfo: VisitorInfo | null = null;
   let chatID: string | null = null;
   let isHandoverActive = false;
+  // MMX-551: signed R2/S3 URL for the assigned sales rep's profile
+  // photo. Captured from the handover_message WS frame and reused on
+  // every subsequent rep text message in the session so the avatar
+  // doesn't flicker back to the default icon mid-conversation.
+  let currentRepPhotoUrl: string | null = null;
   let isFormShowing = false;
   let isBotResponding = false;
   let chatOpen = false;
@@ -469,6 +474,14 @@ async function init(): Promise<void> {
       isHandoverActive = true;
       sessionStore.updateSession({ handoverOccurred: true });
 
+      // MMX-551: stash the rep's signed photo URL so every subsequent
+      // 'sales_rep' message bubble renders the actual avatar. Empty
+      // string is the explicit "no photo set" signal — keep the
+      // default colored icon fallback in that case.
+      if (typeof data.sender_photo_url === 'string') {
+        currentRepPhotoUrl = data.sender_photo_url || '';
+      }
+
       const senderName = data.assigned_user_name
         || (typeof data.sender === 'object' ? data.sender?.name : null)
         || data.sender_name
@@ -570,10 +583,17 @@ async function init(): Promise<void> {
       const content = data.content || '';
       if (!content.trim()) return;
 
+      // MMX-551: capture the latest signed photo URL so subsequent
+      // rep messages on this session render with the same avatar.
+      if (typeof data.sender_photo_url === 'string' && data.sender_photo_url) {
+        currentRepPhotoUrl = data.sender_photo_url;
+      }
+
       sessionStore.pushMessage({
         text: content,
         sender: 'sales_rep',
         senderName: (typeof data.sender === 'string' ? data.sender : data.sender_name) || 'Sales Representative',
+        senderPhotoUrl: currentRepPhotoUrl || undefined,
         isWelcomeMessage: false,
         created_at: formatTimeStamp(data.created_at || new Date().toISOString()),
       });
@@ -772,6 +792,7 @@ async function init(): Promise<void> {
 
     sessionStore.clearAll();
     isHandoverActive = false;
+    currentRepPhotoUrl = null;
     isFormShowing = false;
     window.__simpleChatEmbedLeadCaptured = false;
     visitorInfo = null;

--- a/src/ui/messages/message-bubble.test.ts
+++ b/src/ui/messages/message-bubble.test.ts
@@ -1,0 +1,78 @@
+/**
+ * MMX-551 — sales-rep avatar must render the assigned rep's actual
+ * profile photo (signed R2/S3 URL) when one is supplied, and fall
+ * back to the default colored circle when it isn't.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createMessageBubble } from './message-bubble';
+import type { ChatEmbedConfig, StoredMessage } from '../../config/types';
+
+const config: ChatEmbedConfig = {
+  socketUrl: 'wss://example.com',
+  baseUrl: 'https://example.com/api/v1/',
+  token: 't',
+  org_id: '1',
+  agent_id: '1',
+  theme: {},
+};
+
+function makeMessage(overrides: Partial<StoredMessage> = {}): StoredMessage {
+  return {
+    text: 'Hi, jumping in to help!',
+    sender: 'sales_rep',
+    senderName: 'Alice',
+    created_at: '12:30',
+    ...overrides,
+  };
+}
+
+describe('sales-rep avatar rendering (MMX-551)', () => {
+  it('falls back to the default SVG when no photo URL is supplied', () => {
+    const { container } = createMessageBubble(makeMessage(), config, false);
+    const avatar = container.querySelector('.mcx-avatar--sales_rep') as HTMLElement;
+    expect(avatar).not.toBeNull();
+    // No <img>, the SVG fallback is the only inner content.
+    expect(avatar.querySelector('img')).toBeNull();
+    expect(avatar.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders an <img> overlay when senderPhotoUrl is set', () => {
+    const url = 'https://example.r2.cloudflarestorage.com/bucket/media/user_photos/user_2/abc.png?sig=x';
+    const { container } = createMessageBubble(
+      makeMessage({ senderPhotoUrl: url }),
+      config,
+      false,
+    );
+    const avatar = container.querySelector('.mcx-avatar--sales_rep') as HTMLElement;
+    const img = avatar.querySelector('img') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img.src).toBe(url);
+    // SVG fallback remains in the DOM so an onError silently reveals
+    // it without leaving an empty circle.
+    expect(avatar.querySelector('svg')).not.toBeNull();
+  });
+
+  it('ignores unsafe (javascript:) photo URLs', () => {
+    const { container } = createMessageBubble(
+      makeMessage({ senderPhotoUrl: 'javascript:alert(1)' }),
+      config,
+      false,
+    );
+    const avatar = container.querySelector('.mcx-avatar--sales_rep') as HTMLElement;
+    expect(avatar.querySelector('img')).toBeNull();
+    expect(avatar.querySelector('svg')).not.toBeNull();
+  });
+
+  it('does not render <img> for non-rep senders even when senderPhotoUrl is set', () => {
+    // Photo URLs are scoped to sales rep messages; bot/user/system
+    // bubbles must ignore the field entirely.
+    const { container } = createMessageBubble(
+      makeMessage({ sender: 'user', senderPhotoUrl: 'https://example.com/img.png' }),
+      config,
+      false,
+    );
+    const avatar = container.querySelector('.mcx-avatar--user') as HTMLElement;
+    expect(avatar.querySelector('img')).toBeNull();
+  });
+});

--- a/src/ui/messages/message-bubble.ts
+++ b/src/ui/messages/message-bubble.ts
@@ -8,7 +8,11 @@ export interface BubbleRefs {
   contentWrapper?: HTMLDivElement;
 }
 
-function createAvatar(sender: string, config: ChatEmbedConfig): HTMLDivElement {
+function createAvatar(
+  sender: string,
+  config: ChatEmbedConfig,
+  photoUrl?: string,
+): HTMLDivElement {
   const theme = config.theme || {};
   const av = document.createElement('div');
   av.className = `mcx-avatar mcx-avatar--${sender}`;
@@ -24,8 +28,31 @@ function createAvatar(sender: string, config: ChatEmbedConfig): HTMLDivElement {
   } else if (sender === 'sales_rep') {
     av.style.background = theme.salesRepAvatar || '#DBEAFE';
     av.style.border = theme.salesRepAvatarBorder || 'none';
+    av.style.overflow = 'hidden';
+    av.style.position = 'relative';
     const color = theme.salesRepAvatarSvgColor || theme.primary || '#8349FF';
+    // Default-icon path: shown when no photoUrl is supplied AND as the
+    // fallback rendering beneath the <img> so an onError silently
+    // reveals it without leaving an empty circle.
     av.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`;
+    // MMX-551: signed R2/S3 URL → render the rep's real photo on top.
+    // Built via DOM API (not innerHTML) — the URL comes from the
+    // backend but we still want defense-in-depth against attribute
+    // escape via a stray `"` in a presigned query string.
+    if (photoUrl && isSafeImageUrl(photoUrl)) {
+      const img = document.createElement('img');
+      img.src = photoUrl;
+      img.alt = '';
+      img.style.position = 'absolute';
+      img.style.inset = '0';
+      img.style.width = '100%';
+      img.style.height = '100%';
+      img.style.objectFit = 'cover';
+      img.onerror = () => {
+        img.remove();
+      };
+      av.appendChild(img);
+    }
   } else {
     const bIcon = theme.botIcon || config.botIcon || {};
     av.style.width = bIcon.botIconAvatarWidth || '29px';
@@ -63,7 +90,11 @@ export function createMessageBubble(
   const container = document.createElement('div');
   container.className = `mcx-msg-group${msg.sender === 'user' ? ' mcx-msg-group--user' : ''}`;
 
-  const avatar = createAvatar(msg.sender === 'ai' ? 'bot' : msg.sender, config);
+  const avatar = createAvatar(
+    msg.sender === 'ai' ? 'bot' : msg.sender,
+    config,
+    msg.sender === 'sales_rep' ? msg.senderPhotoUrl : undefined,
+  );
   const bubble = document.createElement('div');
   bubble.className = 'mcx-msg-stack';
   if (msg.sender === 'user') bubble.classList.add('mcx-msg-stack--user');


### PR DESCRIPTION
## Summary
- Adds ``senderPhotoUrl`` to ``StoredMessage`` + ``WsMessageData`` so the chat embed can carry the assigned rep's signed R2/S3 photo URL through to the rendered avatar.
- ``message-bubble.createAvatar`` now overlays an ``<img>`` on the default-colored circle for sales-rep bubbles when the URL is set, falling back to the SVG silently on load failure.
- ``index.ts`` captures the URL from the ``handover_message`` WS frame and from subsequent post-handover ``text`` frames, stamps it on every pushed rep bubble, and clears it in ``resetSession``.

Pairs with [memox-hub PR #366](https://github.com/Memox-Inc/memox-hub/pull/366) (commit ``927745c``) which now forwards ``sender_photo_url`` (signed, 7-day TTL) on the WS consumer side.

## What the customer sees
On a handover, the rep's actual profile photo (uploaded via the dashboard ``/settings/profile`` screen) replaces the generic colored circle next to every subsequent rep message. Reps without a photo set keep the existing fallback — no regression.

## Test plan
- [x] ``npx tsc --noEmit`` clean
- [x] ``npm run build`` produces a 150.76 kB IIFE (45.73 kB gzip)
- [x] ``npm test`` — 173 unit tests pass, including 4 new tests in ``src/ui/messages/message-bubble.test.ts``:
  - default SVG when no URL
  - ``<img>`` rendered when URL is set
  - unsafe ``javascript:`` URLs blocked (defense-in-depth)
  - non-rep senders ignore ``senderPhotoUrl``
- [ ] Manual smoke on ``hub-dev.memox.io``: log in as a rep, set a profile photo, open a chat embed page, trigger handover → rep's actual photo renders in the customer-side avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)