### PR TITLE
MMX-578: auto-purge jsDelivr edge cache after each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,27 @@ jobs:
           git push
           git push origin "v${{ inputs.version }}"
 
+      # MMX-578: jsDelivr keeps the resolution of non-pinned URLs like
+      # ``@v3`` and ``@latest`` cached at its edge for up to 12h (s-maxage).
+      # Without purging, every release silently leaves customers on the
+      # previous bundle until that cache expires — even though the new
+      # tag is published seconds after the workflow finishes. The dashboard
+      # snippet uses ``@v3`` for every customer, so this MUST be invalidated
+      # to make the release actually reach end users.
+      - name: Purge jsDelivr edge cache
+        run: |
+          set -e
+          # `@v3` ambiguous pin — every dashboard-generated snippet uses this.
+          curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v3/dist/chat-embed.js" | head -c 300; echo
+          # `latest.json` so any consumer reading it gets the fresh active-version pointer.
+          curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2/latest.json" | head -c 300; echo
+          # `@latest` semver pin — anyone using this should pick up the new tag immediately.
+          curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@latest/dist/chat-embed.js" | head -c 300; echo
+          # The just-released specific URL. Usually cold (jsDelivr fetches a tag's
+          # first request on demand), but purging is harmless and removes any
+          # accidental stale entry from a prior workflow run.
+          curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v${{ inputs.version }}/dist/chat-embed.js" | head -c 300; echo
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,25 +58,40 @@ jobs:
           git push
           git push origin "v${{ inputs.version }}"
 
-      # MMX-578: jsDelivr keeps the resolution of non-pinned URLs like
-      # ``@v3`` and ``@latest`` cached at its edge for up to 12h (s-maxage).
-      # Without purging, every release silently leaves customers on the
-      # previous bundle until that cache expires — even though the new
-      # tag is published seconds after the workflow finishes. The dashboard
-      # snippet uses ``@v3`` for every customer, so this MUST be invalidated
-      # to make the release actually reach end users.
+      # MMX-578: jsDelivr has TWO cache layers and BOTH must be purged on
+      # every release, or new tags become unreachable for hours:
+      #
+      #   1. Package-level tag index — maps tag names to commit SHAs.
+      #      The metadata API may already know about a new tag, but the
+      #      CDN content layer keeps serving the previous tag list until
+      #      the package URL is purged. Without this, ``@v3`` keeps
+      #      resolving to the prior version AND
+      #      ``@v3.0.18/dist/chat-embed.js`` returns 404 even though the
+      #      tag exists on GitHub. Observed on the v3.0.17 → v3.0.19
+      #      rollout: dashboard snippets kept serving the old bundle for
+      #      ~10 hours and v3.0.18 was 404 on the CDN.
+      #
+      #   2. URL-level edge cache — Cloudflare keeps each rendered URL
+      #      for up to 12h (s-maxage=43200). Even after the tag index is
+      #      refreshed, individual URLs serve stale content until purged.
+      #
+      # The order matters: purge the package index first so the next file
+      # request triggers a fresh tag-to-commit lookup; then purge each
+      # file URL the dashboard / snippets / latest.json consumers use.
       - name: Purge jsDelivr edge cache
         run: |
           set -e
-          # `@v3` ambiguous pin — every dashboard-generated snippet uses this.
+          # 1) Package-level tag index — this is the critical one that
+          #    makes new tags reachable from the CDN content layer.
+          curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2" | head -c 300; echo
+          # 2a) `@v3` ambiguous pin — every dashboard-generated snippet uses this.
           curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v3/dist/chat-embed.js" | head -c 300; echo
-          # `latest.json` so any consumer reading it gets the fresh active-version pointer.
+          # 2b) `latest.json` so any consumer reading it gets the fresh active-version pointer.
           curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2/latest.json" | head -c 300; echo
-          # `@latest` semver pin — anyone using this should pick up the new tag immediately.
+          # 2c) `@latest` semver pin — anyone using this should pick up the new tag immediately.
           curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@latest/dist/chat-embed.js" | head -c 300; echo
-          # The just-released specific URL. Usually cold (jsDelivr fetches a tag's
-          # first request on demand), but purging is harmless and removes any
-          # accidental stale entry from a prior workflow run.
+          # 2d) The just-released specific URL. Usually cold, but on first hit
+          #     it can 404 if step 1 was skipped — see commit message.
           curl -fsSL "https://purge.jsdelivr.net/gh/Memox-Inc/ChatEmbed_V2@v${{ inputs.version }}/dist/chat-embed.js" | head -c 300; echo
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- After every release, hit \`purge.jsdelivr.net\` for the four URL shapes that the dashboard / latest.json / customer snippets actually use, so a new tag actually reaches end users instead of being shadowed by the edge cache for up to 12 hours.

## Why
- jsDelivr's resolution of non-pinned URLs like \`@v3\` is cached at the edge with \`s-maxage=43200\` (12h).
- Today's bot-icon fix shipped in v3.0.18 + v3.0.19 but customers on the \`@v3\` snippet kept seeing the v3.0.17 bundle for ~10 hours until I manually purged.
- Without this fix, every future release has the same delayed-rollout symptom.

## What it covers
1. \`@v3/dist/chat-embed.js\` — the URL the dashboard hardcodes for every customer snippet.
2. \`/latest.json\` — active-version pointer some consumers read.
3. \`@latest/dist/chat-embed.js\` — for anyone using jsDelivr's \`@latest\`.
4. \`@v{version}/dist/chat-embed.js\` — the just-released specific URL (usually cold, but harmless to purge).

## Test plan
- [ ] Trigger a no-op patch release via the workflow and verify the purge step prints \`{"status":"finished",...}\` for all four URLs.
- [ ] Hit one of the URLs immediately after — \`x-jsd-version\` should match the new tag and \`age\` should be ~0.
- [ ] Confirm the rest of the workflow (tag push, GitHub Release creation) still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)