### PR TITLE
MMX-769: send distinct_id on lead capture so Optimize conversions are recorded

### DIFF
--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -1,5 +1,6 @@
 import type { ChatEmbedConfig, VisitorInfo } from '../config/types';
 import { collectBrowserMetadata, createAnonymousEmail } from './browser-metadata';
+import { getOrCreateDistinctId } from '../utils/distinct-id';
 
 function buildHeaders(config: ChatEmbedConfig): Record<string, string> {
   // Prefer the per-session embed token (EmbedTokenAuthentication on the
@@ -110,6 +111,10 @@ export async function createVisitor(
         zip_code: zip || '',
         organization: config.org_id,
         metadata,
+        // Memox Optimize: the backend's lead-capture conversion hook attributes
+        // the conversion to this visitor's bandit assignment by distinct_id.
+        // Without it, conversions for running experiments are never recorded.
+        distinct_id: getOrCreateDistinctId(),
       };
 
       const postResponse = await fetch(`${baseUrl}visitors/`, {


### PR DESCRIPTION
## Problem
Memox Optimize records **impressions but zero conversions** end-to-end in production. Running experiments accumulate impressions (via `/embed/init/`, which sends `distinct_id`) but the conversion count never moves.

## Root cause
The widget's `createVisitor()` (`src/connection/api-client.ts`) builds the visitor-create POST body **without `distinct_id`**:

```js
{ name, email, phone_number, zip_code, organization, metadata }   // no distinct_id
```

The backend conversion hook `_enqueue_bandit_conversions` (memox-hub `visitors/api/v1/views.py`) reads `request.data.get("distinct_id")` to find the visitor's bandit assignment and set `converted_at`. With it missing, the hook receives an empty id and returns early — so a lead capture never converts the assignment.

## Fix
Add `distinct_id: getOrCreateDistinctId()` to the visitor payload. This is the **same** id the widget already sends at `/embed/init/` (assignment) time, so assignment and conversion now correlate. One-line source change.

## Scope / notes
- `src`-only change; `dist/chat-embed.js` is rebuilt + committed by the release workflow (`release.yml`), per repo convention.
- Verified end-to-end against `memox-hub-pr-411`: with this payload, a lead capture flips `ExperimentAssignment.converted_at` and the Optimize dashboard conversion count increments. Found while UAT-testing the Optimize PRs (hub #411 / dashboard #163).
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)