### PR TITLE
MMX-804: persist submitted name for name-only lead forms

### DIFF
--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -77,16 +77,30 @@ export async function createVisitor(
       throw new Error('Missing required configuration: baseUrl and (sessionToken or token)');
     }
 
-    const isAnonymous = !email;
     const browserMetadata = collectBrowserMetadata();
 
-    let visitorEmail = email;
-    let visitorName = name;
+    // MMX-804: "anonymous" means the visitor submitted NO lead data at all —
+    // not merely "no email". Previously this keyed off `!email`, so a name-only
+    // lead form (email/phone/zip disabled) was treated as anonymous and the
+    // submitted name was overwritten with 'Anonymous Visitor' (and the visitor
+    // was never personalized). Determine anonymity from the full payload.
+    const hasLeadData = !!(
+      name ||
+      email ||
+      phone ||
+      zip ||
+      (customFields && Object.keys(customFields).length > 0)
+    );
+    const isAnonymous = !hasLeadData;
 
-    if (isAnonymous) {
-      visitorEmail = createAnonymousEmail(browserMetadata);
-      visitorName = 'Anonymous Visitor';
-    }
+    // Email is the backend's required, per-org-unique visitor identity key
+    // (visitors.email is non-null with a unique (email, organization)
+    // constraint). When the lead form doesn't collect an email, synthesize a
+    // deterministic per-browser address so the visitor can still be looked up /
+    // deduped — but keep whatever name (and other fields) the visitor actually
+    // submitted. Only fall back to the placeholder name when none was given.
+    const visitorEmail = email || createAnonymousEmail(browserMetadata);
+    const visitorName = name || 'Anonymous Visitor';
 
     const headers = buildHeaders(config);
 
@@ -136,9 +150,38 @@ export async function createVisitor(
       const visitorData = await postResponse.json();
       return { id: visitorData.id, name: visitorData.name };
     } else {
+      const existing = getJson.results[0];
+
+      // MMX-804: the synthetic anonymous email is a deterministic per-browser
+      // fingerprint, so a returning visitor who previously submitted nothing
+      // (or whom we'd mislabeled) resolves to the same record. If we now have a
+      // real submitted name but the stored one is still a placeholder, patch it
+      // so the name the visitor just gave is persisted. Best-effort: a failed
+      // PATCH must not break the chat flow.
+      const existingName = String(existing.name ?? '').trim().toLowerCase();
+      const isPlaceholderName =
+        !existingName ||
+        existingName === 'anonymous visitor' ||
+        existingName === 'anonymous user';
+      if (name && isPlaceholderName) {
+        try {
+          const patchResponse = await fetch(`${baseUrl}visitors/${existing.id}/`, {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify({ name }),
+          });
+          if (patchResponse.ok) {
+            const patched = await patchResponse.json();
+            return { id: patched.id, name: patched.name };
+          }
+        } catch (patchError) {
+          console.error('Error updating existing visitor name:', patchError);
+        }
+      }
+
       return {
-        id: getJson.results[0].id,
-        name: getJson.results[0].name,
+        id: existing.id,
+        name: existing.name,
       };
     }
   } catch (error) {

--- a/test/create-visitor.test.ts
+++ b/test/create-visitor.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVisitor } from '../src/connection/api-client';
+import type { ChatEmbedConfig } from '../src/config/types';
+
+// MMX-804: a name-only lead submission (email/phone/zip disabled) must persist
+// the submitted name and create a non-anonymous visitor — not overwrite the
+// name with "Anonymous Visitor".
+
+const CONFIG = {
+  baseUrl: 'https://hub.memox.io/api/v1/',
+  sessionToken: 'sess_test',
+  org_id: 7,
+} as unknown as ChatEmbedConfig;
+
+function bodyOf(call: unknown[]): Record<string, unknown> {
+  const [, options] = call as [string, RequestInit];
+  return JSON.parse(options.body as string);
+}
+
+describe('createVisitor — name-only lead (MMX-804)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    // GET lookup → not found, POST create → echo the payload back with an id.
+    fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (!options || options.method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      }
+      const payload = JSON.parse(options.body as string);
+      return Promise.resolve(
+        new Response(JSON.stringify({ id: 123, ...payload }), { status: 201 }),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('persists the submitted name and marks the visitor non-anonymous', async () => {
+    const result = await createVisitor('Jane Doe', null, null, null, CONFIG);
+
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'POST',
+    );
+    expect(postCall).toBeDefined();
+    const payload = bodyOf(postCall!);
+
+    expect(payload.name).toBe('Jane Doe');
+    expect((payload.metadata as Record<string, unknown>).anonymous).toBe(false);
+    // A synthetic per-browser email is used as the identity key.
+    expect(String(payload.email)).toMatch(/^anonymous_.*@memox\.local$/);
+    expect(result.name).toBe('Jane Doe');
+  });
+
+  it('falls back to the placeholder + anonymous flag when no lead data at all', async () => {
+    await createVisitor(null, null, null, null, CONFIG);
+
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'POST',
+    );
+    const payload = bodyOf(postCall!);
+
+    expect(payload.name).toBe('Anonymous Visitor');
+    expect((payload.metadata as Record<string, unknown>).anonymous).toBe(true);
+  });
+
+  it('keeps the real email + name unchanged for email-bearing submissions', async () => {
+    await createVisitor('Bob', 'bob@acme.com', null, null, CONFIG);
+
+    const postCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'POST',
+    );
+    const payload = bodyOf(postCall!);
+
+    expect(payload.name).toBe('Bob');
+    expect(payload.email).toBe('bob@acme.com');
+    expect((payload.metadata as Record<string, unknown>).anonymous).toBe(false);
+  });
+});
+
+describe('createVisitor — existing placeholder record gets its name patched (MMX-804)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (!options || options.method === 'GET') {
+        // Existing visitor found, still named with the placeholder.
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ results: [{ id: 55, name: 'Anonymous Visitor' }] }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (options.method === 'PATCH') {
+        const payload = JSON.parse(options.body as string);
+        return Promise.resolve(new Response(JSON.stringify({ id: 55, ...payload }), { status: 200 }));
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes the placeholder-named visitor with the newly submitted name', async () => {
+    const result = await createVisitor('Jane Doe', null, null, null, CONFIG);
+
+    const patchCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'PATCH',
+    );
+    expect(patchCall).toBeDefined();
+    expect(String(patchCall![0])).toMatch(/visitors\/55\/$/);
+    expect(JSON.parse((patchCall![1] as RequestInit).body as string).name).toBe('Jane Doe');
+    expect(result.name).toBe('Jane Doe');
+  });
+});


### PR DESCRIPTION
## MMX-804 — Lead capture with only the name field enabled creates an anonymous visitor

### Problem
With lead capture enabled but **only the `name` field on** (email/phone/zip off), submitting the form created the visitor as **"Anonymous Visitor"** (the typed name was discarded) and the server greeting came back as **"Hi Anonymous!"**. Repeat tests from the same browser appeared to "never create" a visitor.

### Root cause
`createVisitor()` keyed anonymity off `!email`:
```ts
const isAnonymous = !email;
if (isAnonymous) { visitorEmail = createAnonymousEmail(...); visitorName = 'Anonymous Visitor'; }
```
A name-only form has no email ⇒ `isAnonymous` true ⇒ **submitted name overwritten**. The synthetic email is a deterministic per-browser fingerprint, so subsequent submits resolve to the same stale record (hence "never creates").

### Fix
- Anonymity now means **no lead data at all** (`name || email || phone || zip || custom`), not merely "no email".
- The synthetic per-browser email is still generated when email is absent (`visitors.email` is required + unique per org on the backend) — but the **submitted name and fields are preserved**.
- If an existing visitor resolves to the synthetic email but is still placeholder-named, **PATCH** it with the newly submitted name (best-effort).

### Tests
- New `test/create-visitor.test.ts` (4 cases): name-only persists name + `metadata.anonymous=false` + synthetic email; no-data falls back to placeholder + anonymous; email-bearing unchanged; existing placeholder record gets PATCHed.
- Full suite: **206 passing**; `vite build` clean.

### Deploy
The platform/embed loads the widget from the moving `ChatEmbed_V2@v3` tag. After merge, release a patch (`gh workflow run release.yml -f version=3.X.Y -f set_active=true`) so `@v3` advances and jsDelivr serves the fix.

Paired backend PR (greeting guard): Memox-Inc/memox-hub `fix/MMX-804-lead-capture-name-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)