### PR TITLE
MMX-894: Handover experience (widget)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -368,7 +368,17 @@ export interface StoredMessage {
   sender: 'user' | 'bot' | 'ai' | 'sales_rep' | 'system';
   isWelcomeMessage?: boolean;
   isSystemNotification?: boolean;
-  notificationType?: 'joined' | 'session_closed' | string;
+  notificationType?: 'joined' | 'session_closed' | 'status' | string;
+  // MMX-894: handover narration phase carried through from the
+  // ``handover_status`` frame (e.g. ``pinging``, ``rep_unavailable``).
+  handoverPhase?: string;
+  // MMX-894: fallback choice buttons (leave a message / talk to
+  // someone else) from a ``handover_choices`` frame. When present the
+  // message renders as an accessible button group instead of a bubble;
+  // ``choicePicked`` records the id once the visitor picks one so a
+  // re-render keeps the buttons disabled.
+  choices?: { id: string; label: string }[];
+  choicePicked?: string;
   isStreaming?: boolean;
   messageId?: string;
   senderName?: string | { name?: string };

--- a/src/connection/websocket-manager.ts
+++ b/src/connection/websocket-manager.ts
@@ -20,6 +20,14 @@ export interface WsMessageData {
   sender_photo_url?: string;
   assigned_user_name?: string;
   assigned_user_email?: string;
+  // MMX-894: deterministic handover narration phase, carried on
+  // ``handover_status`` frames so the widget can reflect distinct
+  // states (e.g. a "waiting for {rep}" cue on ``pinging``).
+  phase?: string;
+  // MMX-894: fallback choice buttons shipped on ``handover_choices``
+  // frames (e.g. leave a message / talk to someone else). Rendered as
+  // accessible buttons; a pick sends a ``choice`` frame back.
+  choices?: { id: string; label: string }[];
 }
 
 export class WebSocketManager {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { createHeader } from './ui/header';
 import { createMessageList } from './ui/messages/message-list';
 import { createMessageBubble } from './ui/messages/message-bubble';
 import { createSystemNotification } from './ui/messages/system-notification';
+import { createChoicesBubble } from './ui/messages/choices-bubble';
 import { createSessionEndedToast, type SessionEndedToastHandle } from './ui/messages/session-ended-toast';
 import { StreamingRenderer } from './ui/messages/streaming-renderer';
 import { createInputBar } from './ui/input/input-bar';
@@ -378,6 +379,19 @@ async function init(): Promise<void> {
       const msg = msgs[i];
       const isLast = i === msgs.length - 1;
 
+      // MMX-894: handover fallback choices render as a button group.
+      // ``choicePicked`` (set once the visitor picks) is threaded into
+      // the component so a full re-render keeps the buttons disabled.
+      if (msg.choices && msg.choices.length > 0) {
+        const idx = i;
+        const choicesEl = createChoicesBubble(msg, (choice) => {
+          handleChoice(idx, choice);
+        });
+        messagesEl.appendChild(choicesEl);
+        renderedCount++;
+        continue;
+      }
+
       if (msg.isSystemNotification) {
         const notif = createSystemNotification(
           msg,
@@ -510,6 +524,43 @@ async function init(): Promise<void> {
         isWelcomeMessage: false,
         isSystemNotification: true,
         notificationType: 'joined',
+        created_at: formatTimeStamp(data.created_at || new Date().toISOString()),
+      });
+      loadMessages();
+      return;
+    }
+
+    // MMX-894: deterministic handover narration — render as a system
+    // status line. The ``pinging`` phase reflects a "waiting for {rep}"
+    // cue; all phases render through the shared system-notification
+    // styling (notificationType 'status').
+    if (data.message_type === 'handover_status') {
+      const statusText = data.content || data.message || '';
+      if (!statusText.trim()) return;
+      sessionStore.pushMessage({
+        text: statusText,
+        sender: 'system',
+        isWelcomeMessage: false,
+        isSystemNotification: true,
+        notificationType: 'status',
+        handoverPhase: typeof data.phase === 'string' ? data.phase : undefined,
+        created_at: formatTimeStamp(data.created_at || new Date().toISOString()),
+      });
+      loadMessages();
+      return;
+    }
+
+    // MMX-894: fallback choices (leave a message / talk to someone
+    // else). Rendered as an accessible button group; a pick sends a
+    // ``choice`` frame and echoes the label as a user bubble.
+    if (data.message_type === 'handover_choices') {
+      const choices = Array.isArray(data.choices) ? data.choices : [];
+      if (choices.length === 0) return;
+      sessionStore.pushMessage({
+        text: data.content || data.message || '',
+        sender: 'system',
+        isWelcomeMessage: false,
+        choices,
         created_at: formatTimeStamp(data.created_at || new Date().toISOString()),
       });
       loadMessages();
@@ -671,6 +722,46 @@ async function init(): Promise<void> {
         setBotResponding(false);
         loadMessages();
       }
+    }
+  }
+
+  // MMX-894: visitor picked a handover fallback choice. Persist the
+  // pick so a re-render keeps the buttons disabled, send the ``choice``
+  // frame back to the orchestrator, and echo the chosen label as a user
+  // bubble so the transcript reads naturally.
+  function handleChoice(msgIndex: number, choice: { id: string; label: string }): void {
+    const msgs = sessionStore.getMessages();
+    const target = msgs[msgIndex];
+    // Guard against a double pick if the same index re-fires.
+    if (target && target.choices && target.choicePicked) return;
+    if (target && target.choices) {
+      target.choicePicked = choice.id;
+      msgs[msgIndex] = target;
+      sessionStore.setMessages(msgs);
+    }
+
+    // Echo the chosen label as a user bubble.
+    saveMessage(choice.label, 'user');
+    loadMessages();
+
+    const payload = {
+      message_type: 'choice',
+      choice_id: choice.id,
+      room_name: chatID,
+    };
+    if (ws.connected && ws.readyState === WebSocket.OPEN) {
+      ws.send(payload);
+    } else {
+      connectWebSocket();
+      const checkAndSend = (): void => {
+        if (!chatID) return;
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(payload);
+        } else if (ws.readyState === WebSocket.CONNECTING) {
+          setTimeout(checkAndSend, 100);
+        }
+      };
+      setTimeout(checkAndSend, 500);
     }
   }
 

--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -779,6 +779,62 @@
   border-left-color: #8349FF;
 }
 
+/* ═══════ Handover fallback choices (MMX-894) ═══════ */
+.mcx-choices-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  margin: 6px 0;
+  animation: mcx-msg-in 300ms ease-out;
+}
+.mcx-choices-prompt {
+  max-width: 90%;
+  font-size: 12.5px;
+  color: #64748B;
+  text-align: center;
+  line-height: 1.4;
+}
+.mcx-choices-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 90%;
+}
+.mcx-choice-btn {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1.5px solid var(--p);
+  background: #fff;
+  color: var(--p);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: center;
+  transition: background 120ms ease-out, color 120ms ease-out, transform 120ms ease-out, opacity 120ms ease-out;
+}
+.mcx-choice-btn:hover:not(:disabled) {
+  background: var(--p);
+  color: #fff;
+}
+.mcx-choice-btn:active:not(:disabled) { transform: translateY(1px); }
+.mcx-choice-btn:focus-visible {
+  outline: 2px solid var(--p);
+  outline-offset: 2px;
+}
+.mcx-choice-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.mcx-choice-btn--picked {
+  background: var(--p);
+  color: #fff;
+  opacity: 1;
+}
+
 /* ═══════ Quick Questions ═══════ */
 .mcx-quick-questions {
   padding: 0 14px 8px;

--- a/src/ui/messages/choices-bubble.test.ts
+++ b/src/ui/messages/choices-bubble.test.ts
@@ -1,0 +1,87 @@
+/**
+ * MMX-894 — handover fallback-choice buttons. The widget renders a
+ * ``handover_choices`` frame as an accessible button group; picking one
+ * fires the callback with the chosen id/label and disables the group so
+ * a session can't pick twice.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createChoicesBubble } from './choices-bubble';
+import type { StoredMessage } from '../../config/types';
+
+function makeMessage(overrides: Partial<StoredMessage> = {}): StoredMessage {
+  return {
+    text: 'I could not reach anyone right now.',
+    sender: 'system',
+    choices: [
+      { id: 'leave_message', label: 'Leave a message' },
+      { id: 'talk_to_someone_else', label: 'Talk to someone else' },
+    ],
+    created_at: '12:30',
+    ...overrides,
+  };
+}
+
+describe('handover choices bubble (MMX-894)', () => {
+  it('renders one button per choice with the choice label + id', () => {
+    const el = createChoicesBubble(makeMessage(), vi.fn());
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.mcx-choice-btn');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].textContent).toBe('Leave a message');
+    expect(buttons[0].dataset.choiceId).toBe('leave_message');
+    expect(buttons[1].dataset.choiceId).toBe('talk_to_someone_else');
+    // All buttons are type=button so they never submit a parent form.
+    expect(buttons[0].type).toBe('button');
+  });
+
+  it('renders the prompt text and an accessible group', () => {
+    const el = createChoicesBubble(makeMessage(), vi.fn());
+    const prompt = el.querySelector('.mcx-choices-prompt');
+    expect(prompt?.textContent).toBe('I could not reach anyone right now.');
+    const group = el.querySelector('.mcx-choices-group');
+    expect(group?.getAttribute('role')).toBe('group');
+  });
+
+  it('fires onChoice with the right id + label when a button is clicked', () => {
+    const onChoice = vi.fn();
+    const el = createChoicesBubble(makeMessage(), onChoice);
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.mcx-choice-btn');
+    buttons[1].click();
+    expect(onChoice).toHaveBeenCalledTimes(1);
+    expect(onChoice).toHaveBeenCalledWith({
+      id: 'talk_to_someone_else',
+      label: 'Talk to someone else',
+    });
+  });
+
+  it('disables all buttons after a pick and marks the chosen one', () => {
+    const el = createChoicesBubble(makeMessage(), vi.fn());
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.mcx-choice-btn');
+    buttons[0].click();
+    expect(buttons[0].disabled).toBe(true);
+    expect(buttons[1].disabled).toBe(true);
+    expect(buttons[0].classList.contains('mcx-choice-btn--picked')).toBe(true);
+    expect(buttons[0].getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does not fire onChoice a second time once a pick is made', () => {
+    const onChoice = vi.fn();
+    const el = createChoicesBubble(makeMessage(), onChoice);
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.mcx-choice-btn');
+    buttons[0].click();
+    buttons[1].click();
+    buttons[0].click();
+    expect(onChoice).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders already-disabled with the picked button marked when choicePicked is set', () => {
+    const el = createChoicesBubble(
+      makeMessage({ choicePicked: 'leave_message' }),
+      vi.fn(),
+    );
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.mcx-choice-btn');
+    expect(buttons[0].disabled).toBe(true);
+    expect(buttons[1].disabled).toBe(true);
+    expect(buttons[0].classList.contains('mcx-choice-btn--picked')).toBe(true);
+  });
+});

--- a/src/ui/messages/choices-bubble.ts
+++ b/src/ui/messages/choices-bubble.ts
@@ -1,0 +1,71 @@
+import type { StoredMessage } from '../../config/types';
+
+/**
+ * MMX-894 — fallback-choice buttons for the handover orchestrator.
+ *
+ * When the backend can't connect the visitor to a rep it emits a
+ * ``handover_choices`` frame (e.g. "leave a message" / "talk to someone
+ * else"). We render those as an accessible button group: a status line
+ * (``msg.text``) followed by one ``<button.mcx-choice-btn>`` per choice.
+ *
+ * ``onChoice`` fires with the chosen ``{id, label}`` when a button is
+ * clicked. Once a pick is made (either live, via the click handler, or
+ * on re-render when ``msg.choicePicked`` is already set) every button is
+ * disabled so a session can't fire the same choice twice.
+ */
+export function createChoicesBubble(
+  msg: StoredMessage,
+  onChoice: (choice: { id: string; label: string }) => void,
+): HTMLDivElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'mcx-choices-wrap';
+
+  if (msg.text) {
+    const prompt = document.createElement('div');
+    prompt.className = 'mcx-choices-prompt';
+    // Plain text only — set via textContent, never innerHTML.
+    prompt.textContent = msg.text;
+    wrapper.appendChild(prompt);
+  }
+
+  const group = document.createElement('div');
+  group.className = 'mcx-choices-group';
+  group.setAttribute('role', 'group');
+  if (msg.text) group.setAttribute('aria-label', msg.text);
+
+  const buttons: HTMLButtonElement[] = [];
+  const alreadyPicked = Boolean(msg.choicePicked);
+
+  const choices = msg.choices || [];
+  for (const choice of choices) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mcx-choice-btn';
+    btn.textContent = choice.label;
+    btn.dataset.choiceId = choice.id;
+
+    if (alreadyPicked) {
+      btn.disabled = true;
+      if (msg.choicePicked === choice.id) {
+        btn.classList.add('mcx-choice-btn--picked');
+        btn.setAttribute('aria-pressed', 'true');
+      }
+    }
+
+    btn.addEventListener('click', () => {
+      // First terminal pick wins — guard against double-clicks and any
+      // button in the group being re-activated.
+      if (buttons.some((b) => b.disabled)) return;
+      for (const b of buttons) b.disabled = true;
+      btn.classList.add('mcx-choice-btn--picked');
+      btn.setAttribute('aria-pressed', 'true');
+      onChoice({ id: choice.id, label: choice.label });
+    });
+
+    buttons.push(btn);
+    group.appendChild(btn);
+  }
+
+  wrapper.appendChild(group);
+  return wrapper;
+}


### PR DESCRIPTION
## MMX-894 — Handover experience (widget, V3)

Widget half of the [Intelligent Handoff Orchestrator](https://github.com/Memox-Inc/memox-workspace/blob/main/docs/specs/handover-experience/01-technical-spec.md) (Epic **MMX-643**). Pairs with the `memox-hub` + `mmx-unified-chat` PRs on the same branch slug.

### What this adds
Lets the widget render the orchestrator's interactive offline flow (Phase-2 `choices` message type):
- **`handover_status`** — deterministic narration lines ("Looking up your information…", "Pinging {rep}…", "{rep} isn't available…") rendered as system status lines.
- **`handover_choices`** — new `createChoicesBubble()` renders accessible `<button>`s ("Leave a message" / "Talk to someone else"). Clicking sends `{message_type:"choice", choice_id, room_name}` back to the backend, echoes the chosen label as a user bubble, and disables the group after a pick.

Existing `handover_message` join UI + rep avatar (MMX-551) are untouched. V1 (frozen vanilla JS) is not modified. `dist/` is not committed (the release workflow cuts that at tag time, per convention).

### Testing
- `npx tsc --noEmit` — clean.
- `vite build` — succeeds.
- `npx vitest run` — 212 passed (6 new in `choices-bubble.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
