### PR TITLE
MMX-895: URL-encode visitor lookup + per-browser anonymous email

### DIFF
--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -1,6 +1,6 @@
 import type { ChatEmbedConfig, VisitorInfo } from '../config/types';
 import { getOrCreateDistinctId } from '../utils/distinct-id';
-import { collectBrowserMetadata, createAnonymousEmail } from './browser-metadata';
+import { createAnonymousEmail } from './browser-metadata';
 
 function buildHeaders(config: ChatEmbedConfig): Record<string, string> {
   // Prefer the per-session embed token (EmbedTokenAuthentication on the
@@ -77,8 +77,6 @@ export async function createVisitor(
       throw new Error('Missing required configuration: baseUrl and (sessionToken or token)');
     }
 
-    const browserMetadata = collectBrowserMetadata();
-
     // MMX-804: "anonymous" means the visitor submitted NO lead data at all —
     // not merely "no email". Previously this keyed off `!email`, so a name-only
     // lead form (email/phone/zip disabled) was treated as anonymous and the
@@ -99,7 +97,7 @@ export async function createVisitor(
     // deterministic per-browser address so the visitor can still be looked up /
     // deduped — but keep whatever name (and other fields) the visitor actually
     // submitted. Only fall back to the placeholder name when none was given.
-    const visitorEmail = email || createAnonymousEmail(browserMetadata);
+    const visitorEmail = email || createAnonymousEmail();
     const visitorName = name || 'Anonymous Visitor';
 
     const headers = buildHeaders(config);

--- a/src/connection/api-client.ts
+++ b/src/connection/api-client.ts
@@ -104,8 +104,12 @@ export async function createVisitor(
 
     const headers = buildHeaders(config);
 
-    // Lookup existing visitor
-    const getResponse = await fetch(`${baseUrl}visitors/?email=${visitorEmail}`, {
+    // Lookup existing visitor.
+    // MMX-895: the email MUST be URL-encoded. Unencoded, a "+" in the address
+    // (e.g. "jane+leads@acme.com") is decoded server-side as a space, so the
+    // lookup never matches the stored row — the widget then POSTs a duplicate
+    // that violates unique(email, organization) → 500 → visitorless session.
+    const getResponse = await fetch(`${baseUrl}visitors/?email=${encodeURIComponent(visitorEmail)}`, {
       method: 'GET',
       headers,
     });

--- a/src/connection/browser-metadata.ts
+++ b/src/connection/browser-metadata.ts
@@ -15,7 +15,7 @@ export function collectBrowserMetadata(): BrowserMetadata {
   };
 }
 
-export function createAnonymousEmail(_metadata?: BrowserMetadata): string {
+export function createAnonymousEmail(): string {
   // MMX-895: key the anonymous visitor's synthetic email to the stable
   // per-BROWSER distinct_id (localStorage), NOT to a userAgent/device
   // fingerprint. The old fingerprint was identical for every visitor on the

--- a/src/connection/browser-metadata.ts
+++ b/src/connection/browser-metadata.ts
@@ -1,4 +1,5 @@
 import type { BrowserMetadata } from '../config/types';
+import { getOrCreateDistinctId } from '../utils/distinct-id';
 
 export function collectBrowserMetadata(): BrowserMetadata {
   return {
@@ -14,21 +15,16 @@ export function collectBrowserMetadata(): BrowserMetadata {
   };
 }
 
-export function createAnonymousEmail(metadata: BrowserMetadata): string {
-  const fingerprintData = [
-    metadata.userAgent,
-    metadata.platform,
-    metadata.language,
-    metadata.screenResolution,
-    metadata.timezone,
-    metadata.cookiesEnabled,
-    navigator.hardwareConcurrency || 'unknown',
-    navigator.maxTouchPoints || 0,
-    screen.colorDepth || 'unknown',
-    new Date().getTimezoneOffset(),
-  ].join('|');
-
-  const fingerprint = btoa(fingerprintData)
+export function createAnonymousEmail(_metadata?: BrowserMetadata): string {
+  // MMX-895: key the anonymous visitor's synthetic email to the stable
+  // per-BROWSER distinct_id (localStorage), NOT to a userAgent/device
+  // fingerprint. The old fingerprint was identical for every visitor on the
+  // same browser + OS + screen + timezone, so two different people collided on
+  // one ``anonymous_<fp>@memox.local`` — the second one's POST /visitors/ then
+  // violated unique(email, organization) → 500 → visitorless session → broken
+  // bot. A per-browser id keeps a returning anonymous visitor stable (same id
+  // reused, so their history stitches) while making distinct people distinct.
+  const fingerprint = getOrCreateDistinctId()
     .replace(/[^a-zA-Z0-9]/g, '')
     .substring(0, 40);
 

--- a/test/visitor-anon-and-encoding-mmx895.test.ts
+++ b/test/visitor-anon-and-encoding-mmx895.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVisitor } from '../src/connection/api-client';
+import { createAnonymousEmail } from '../src/connection/browser-metadata';
+import type { ChatEmbedConfig } from '../src/config/types';
+
+// MMX-895 — two widget-side contributors to the "anonymous chats" bug:
+//  (1) the GET lookup pasted the email unencoded, so a "+" address was
+//      decoded server-side as a space → the lookup missed the existing row →
+//      the widget POSTed a duplicate → 500 → visitor-less session.
+//  (2) the synthetic anonymous email was keyed to a userAgent/device
+//      fingerprint, identical for every visitor on the same browser, so two
+//      different people collided on one email → the second one's create 500'd.
+
+const CONFIG = {
+  baseUrl: 'https://hub.memox.io/api/v1/',
+  sessionToken: 'sess_test',
+  org_id: 7,
+} as unknown as ChatEmbedConfig;
+
+describe('createVisitor — GET lookup URL-encodes the email (MMX-895)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn().mockImplementation((_url: string, options?: RequestInit) => {
+      if (!options || options.method === 'GET') {
+        return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      }
+      const payload = JSON.parse(options.body as string);
+      return Promise.resolve(new Response(JSON.stringify({ id: 1, ...payload }), { status: 201 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('encodes "+" as %2B so the lookup matches the stored row', async () => {
+    await createVisitor('Jane', 'jane+leads@acme.com', null, null, CONFIG);
+
+    const getCall = fetchMock.mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'GET' || c[1] === undefined,
+    );
+    expect(getCall).toBeDefined();
+    const url = String(getCall![0]);
+    expect(url).toContain('email=jane%2Bleads%40acme.com');
+    expect(url).not.toContain('jane+leads@acme.com'); // never sent raw
+  });
+});
+
+describe('createAnonymousEmail — per-browser, not per-device (MMX-895)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('produces a memox.local anonymous address', () => {
+    const email = createAnonymousEmail();
+    expect(email).toMatch(/^anonymous_[a-zA-Z0-9]+@memox\.local$/);
+  });
+
+  it('is stable across calls in the same browser (returning visitor resolves to one row)', () => {
+    const a = createAnonymousEmail();
+    const b = createAnonymousEmail();
+    expect(a).toBe(b);
+  });
+
+  it('differs once the browser identity differs (two people no longer collide)', () => {
+    const first = createAnonymousEmail();
+    // A different browser / cleared identity → a fresh distinct_id → distinct email.
+    localStorage.clear();
+    const second = createAnonymousEmail();
+    expect(second).not.toBe(first);
+  });
+});


### PR DESCRIPTION
Widget half of the lost-lead / "anonymous chats" fix. Pairs with **memox-hub#495** (matching branch `fix/MMX-895-visitor-upsert-lead-loss`), which makes `POST /visitors/` idempotent + null-guards the bot.

Two widget-side contributors to the bug:

- **`api-client.ts`** — URL-encode the email in the GET lookup. Unencoded, a `+` in an address (e.g. `jane+leads@acme.com`) was decoded server-side as a space, so the pre-check never matched the stored row → the widget POSTed a duplicate that violated `unique(email, organization)` → 500 → visitorless session → broken bot.
- **`browser-metadata.ts`** — key the synthetic anonymous email to the stable per-**browser** `distinct_id` (localStorage) instead of a `userAgent`/device fingerprint. The old fingerprint was identical for everyone on the same browser + OS + screen + timezone, so two different people collided on one `anonymous_<fp>@memox.local` and the second one's create 500'd. A per-browser id keeps a returning anonymous visitor stable (history stitches) while making distinct people distinct.

## Tests
`test/visitor-anon-and-encoding-mmx895.test.ts`: GET encodes `+` as `%2B` and never sends it raw; anonymous email matches `anonymous_…@memox.local`, is stable across calls in the same browser, and differs once the browser identity differs. Full vitest suite green (210 tests); `tsc --noEmit` clean.

## Deploy note
Changing the anonymous email's basis from a device fingerprint to the per-browser `distinct_id` means existing anonymous `Visitor` rows become unreachable by their original browser after this ships: the GET pre-check computes a different email, misses the old row, and creates a fresh one. Net effect is a **one-time silent history reset for returning anonymous visitors** (not a crash). This is the intended trade-off — the old fingerprint was actively conflating unrelated visitors (the bug being fixed) — but worth noting so a reset anonymous-lead count in the dashboard post-deploy isn't a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
