### PR TITLE
MMX-918: fix collapsed paragraph spacing in bot messages

### DIFF
--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -590,6 +590,15 @@
 }
 
 /* Markdown content styles inside bubbles */
+/* Paragraphs are flush at the bubble edges but spaced from the previous
+   block, so multi-paragraph bot replies (pricing option lists, etc.) don't
+   collapse into a wall of text (MMX-918). */
+.mcx-bubble p { margin: 0; }
+.mcx-bubble p + p,
+.mcx-bubble ul + p,
+.mcx-bubble ol + p,
+.mcx-bubble blockquote + p,
+.mcx-bubble pre + p { margin-top: 8px; }
 .mcx-bubble ul { list-style-type: disc; margin: 8px 0; padding-left: 24px; }
 .mcx-bubble ol { list-style-type: decimal; margin: 8px 0; padding-left: 24px; }
 .mcx-bubble li { margin: 4px 0; }

--- a/src/ui/messages/markdown-renderer.test.ts
+++ b/src/ui/messages/markdown-renderer.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { markdownToHtml } from './markdown-renderer';
+
+describe('markdownToHtml paragraph spacing (MMX-918)', () => {
+  it('renders blank-line-separated blocks as separate paragraphs', () => {
+    const text =
+      'Here are some options:\n\n• 40ft container, price: $4,240\n\n• 40ft Double Door, price: $4,929';
+    const html = markdownToHtml(text);
+    const paragraphs = html.match(/<p /g) ?? [];
+    expect(paragraphs.length).toBe(3);
+  });
+
+  it('does not force margin:0 inline on paragraphs (stylesheet controls spacing)', () => {
+    const html = markdownToHtml('First paragraph.\n\nSecond paragraph.');
+    expect(html).toContain('<p ');
+    expect(html).not.toMatch(/<p[^>]*margin\s*:\s*0/);
+  });
+
+  it('keeps inherited typography styles on paragraphs', () => {
+    const html = markdownToHtml('Hello.');
+    expect(html).toMatch(/<p[^>]*font-size:inherit/);
+  });
+});

--- a/src/ui/messages/markdown-renderer.ts
+++ b/src/ui/messages/markdown-renderer.ts
@@ -10,10 +10,13 @@ export function markdownToHtml(text: string, botTextColor?: string): string {
   try {
     let result = marked.parse(text) as string;
 
-    // Style paragraphs
+    // Style paragraphs. No inline margin here — inter-block spacing lives in
+    // the `.mcx-bubble p` rules in widget.css. An inline margin:0 would beat
+    // the stylesheet and collapse multi-paragraph replies (e.g. bullet-
+    // separated pricing options) into a wall of text (MMX-918).
     result = result.replace(
       /<p>/g,
-      '<p style="font-size:inherit;line-height:inherit;font-family:inherit;font-weight:inherit;margin:0;">',
+      '<p style="font-size:inherit;line-height:inherit;font-family:inherit;font-weight:inherit;">',
     );
 
     // Style links


### PR DESCRIPTION
## Problem
Bot replies with blank-line-separated blocks (e.g. Container One pricing option lists) render as a wall of text — zero vertical spacing between options.

**Root cause:** `markdownToHtml` injects `margin:0` inline on every `<p>`, which overrides any stylesheet rule, so consecutive paragraphs collapse together.

## Fix
- Remove the inline margin from the `<p>` replacement (keeps the inherit-typography styles).
- Control spacing from `widget.css`: `.mcx-bubble p { margin: 0 }` + an 8px `margin-top` on any block that follows another block (`p+p`, `ul+p`, `ol+p`, `blockquote+p`, `pre+p`). Paragraphs stay flush at the bubble edges.
- Welcome-message per-paragraph styling still works (it sets inline margins explicitly, which win as before).

## Verification
- `npm test`: 213/213 pass (3 new tests for the renderer).
- `npx tsc --noEmit`: clean.
- Live UAT against hub-dev (built bundle, real Container One conversation): options render as distinct blocks with measured 8px gaps.

| Before | After |
|---|---|
| all options in one unbroken block | each option a spaced paragraph |

🤖 Generated with [Claude Code](https://claude.com/claude-code)