### PR TITLE
MMX-928: close leaked WebSocket + embed-config listener in destroy()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ async function init(): Promise<void> {
   // ``/ws/embed/<embed_id>/`` and re-applies CSS theme + welcome on
   // every operator save. No-op when ``embedId`` is unset (e.g.
   // self-hosted/OSS deployments).
-  startEmbedConfigListener(config, root, (next) => {
+  const embedConfigListener = startEmbedConfigListener(config, root, (next) => {
     if (!next) return;
     // Run every server payload through the same normalizer the boot
     // path uses, then mutate the in-memory config so a future panel
@@ -314,8 +314,11 @@ async function init(): Promise<void> {
   }
 
   // Public destroy() — removes the mousedown listener, cleans up every
-  // mounted attractor handle, and detaches the shadow host from the DOM.
-  // Safe to call multiple times.
+  // mounted attractor handle, closes the app WebSocket + embed-config
+  // listener (MMX-928: both used to leak past destroy(), leaving a zombie
+  // instance whose stray WS frames raced a freshly booted instance on the
+  // shared localStorage message array), and detaches the shadow host from
+  // the DOM. Safe to call multiple times.
   const destroy = (): void => {
     document.removeEventListener('mousedown', onDocumentMouseDown);
     for (const handle of mountedAttractors) {
@@ -326,6 +329,16 @@ async function init(): Promise<void> {
       }
     }
     mountedAttractors.length = 0;
+    try {
+      ws.close();
+    } catch (e) {
+      console.warn('MemoxChatWidget: websocket close failed', e);
+    }
+    try {
+      embedConfigListener.stop();
+    } catch (e) {
+      console.warn('MemoxChatWidget: embed-config listener stop failed', e);
+    }
     host.remove();
   };
   window.MemoxChatWidget = { destroy };


### PR DESCRIPTION
## Summary

`window.MemoxChatWidget.destroy()` in `src/index.ts` removed the outside-click listener, cleaned up attractor handles, and detached the shadow host from the DOM, but never tore down two live connections:

1. **App WebSocket** — the `WebSocketManager` instance (`ws`) was never `close()`d. Its `close()` (in `src/connection/websocket-manager.ts`) is idempotent: it null-checks the socket, clears the heartbeat interval, and sets `intentionallyClosed` so `tryReconnect()` won't refire.
2. **Embed-config listener** — `startEmbedConfigListener(config, root, ...)` returns a `{ stop }` handle that was discarded, so its socket + reconnect timer kept running.

### Consequence being fixed

Every re-boot path (persona switch, owner handoff on the marketing site, retry) calls `window.MemoxChatWidget.destroy()` then boots a fresh script instance. Because the old instance's socket and message handler stayed alive, the zombie instance kept receiving frames and raced the new instance on the shared `localStorage` message array (`lastMessage.text += content`), interleaving duplicate streamed tokens — visible as doubled/garbled text like "No,No, there's there's...". The website's `runtime.ts` `destroyChatRuntime()` already had a comment flagging this exact gap as an MMX-821 follow-up.

## Fix

In `src/index.ts`:
- Captured the `startEmbedConfigListener(...)` return value into `const embedConfigListener` (previously discarded).
- In `destroy()`, added `ws.close()` and `embedConfigListener.stop()`, each wrapped in `try/catch` with `console.warn` on failure — matching the existing style used for attractor cleanup, and defensive against `destroy()` theoretically running before `ws`/`embedConfigListener` are used (both are declared before `destroy` in the same closure, so this is a belt-and-braces guard, not a required fix for the current call order).

Diff is limited to `src/index.ts` (16 insertions, 3 deletions). No refactors, no other files touched.

## Verification

- `npx tsc --noEmit` — clean, no errors.
- `npm run build` (Vite) — builds clean, bundle size unchanged (~154.65 kB / 46.74 kB gzip). `dist/chat-embed.js` was reverted after the local build check since it's only committed by the release workflow, not by this PR.
- `npm test` (vitest) — all 213 tests / 27 files pass.
- Manual repro path (documented, not re-run against a live backend in this session): boot the widget, call `window.MemoxChatWidget.destroy()`, boot a second instance via the same bootstrap path (e.g. the website's `bootChatEmbed`), and confirm in the Network tab that the first instance's `/ws/app/` and `/ws/embed/<id>/` connections both close (readyState transitions to CLOSING/CLOSED) instead of staying open and continuing to receive frames.

## Blast radius

All embed owners (marketing site persona switches, dashboard demo embeds, any customer page calling `destroy()` before re-bootstrapping) go through this single `destroy()` function. Both new close calls target idempotent APIs (`WebSocketManager.close()` already null-checks; `EmbedConfigListenerHandle.stop()` already null-checks its socket), so calling them from a path that also independently calls `ws.close()` elsewhere (e.g. `resetSession()`) is safe — no double-close errors.

Does not touch the release workflow. `dist/chat-embed.js` is unchanged in this PR; the next tagged release will pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>