### PR TITLE
fix: increase embed init timeout from 1500ms to 5000ms

### DIFF
--- a/src/connection/init.ts
+++ b/src/connection/init.ts
@@ -9,8 +9,9 @@
 // widget renders with the round/bubble defaults instead of the
 // per-embed attractor variant.
 //
-// A 1500ms abort timeout prevents a hanging server from blocking widget
-// bootstrap indefinitely. On timeout the AbortError is caught by the
+// A 5000ms abort timeout prevents a hanging server from blocking widget
+// bootstrap indefinitely while leaving enough headroom for the CORS
+// preflight round-trip. On timeout the TimeoutError is caught by the
 // existing catch block which logs a warning and returns {}.
 //
 // Note: keepalive is intentionally omitted — it conflicts with AbortSignal
@@ -28,8 +29,11 @@ export interface InitResponse {
 
 export type { ExperimentAssignment };
 
-/** Abort the init fetch after this many milliseconds to unblock widget bootstrap. */
-const INIT_TIMEOUT_MS = 1500;
+/** Abort the init fetch after this many milliseconds to unblock widget bootstrap.
+ *  5000ms gives cross-origin POST (with CORS preflight) enough headroom — the
+ *  OPTIONS round-trip + DNS + TLS + POST routinely takes 1-3s depending on
+ *  network conditions. 1500ms was too tight and caused spurious AbortErrors. */
+const INIT_TIMEOUT_MS = 5000;
 
 export async function fetchInitConfig(
   embedId: string | null,
@@ -39,7 +43,10 @@ export async function fetchInitConfig(
   if (!embedId) return {};
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), INIT_TIMEOUT_MS);
+  const timeoutId = setTimeout(
+    () => controller.abort(new DOMException('Init fetch timed out', 'TimeoutError')),
+    INIT_TIMEOUT_MS,
+  );
 
   try {
     const base = apiBase.replace(/\/$/, '');


### PR DESCRIPTION
## Problem
The chat embed's `fetchInitConfig()` had a 1500ms timeout for the POST to `/api/v1/embed/init/`. This is a cross-origin request requiring a CORS preflight (OPTIONS round-trip + DNS + TLS + POST), which routinely takes 1-3 seconds. When the timeout fires, the widget falls back to empty config — and since MMX-628 removed the `token` fallback, the widget has no auth credentials and cannot connect.

Users see: `[Memox] init fetch failed, falling back to local config AbortError: signal is aborted without reason`

## Fix
1. **Increased timeout from 1500ms → 5000ms** — gives the CORS preflight enough headroom without blocking bootstrap unreasonably
2. **Pass a `DOMException` reason to `controller.abort()`** — changes the error from confusing `AbortError: signal is aborted without reason` to clear `TimeoutError: Init fetch timed out`

## Files changed
- `src/connection/init.ts` — `INIT_TIMEOUT_MS` constant + `controller.abort()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)