### PR TITLE
fix: update test timer advances for 5000ms init timeout

### DIFF
--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -114,7 +114,7 @@ describe('fetchInitConfig', () => {
     ));
 
     const promise = fetchInitConfig('test-embed-id', 'https://api.example.com');
-    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(6000);
     const result = await promise;
     expect(result).toEqual({});
 
@@ -137,7 +137,7 @@ describe('fetchInitConfig', () => {
     // console.warn call (abort on an already-resolved fetch). The spy on
     // console.warn is set up in beforeEach — if it was called it means the
     // timer leaked and fired.
-    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(6000);
     // console.warn should NOT have been called (no abort on a successful fetch)
     expect(console.warn).not.toHaveBeenCalled();
 

--- a/src/connection/init.ts
+++ b/src/connection/init.ts
@@ -9,8 +9,9 @@
 // widget renders with the round/bubble defaults instead of the
 // per-embed attractor variant.
 //
-// A 1500ms abort timeout prevents a hanging server from blocking widget
-// bootstrap indefinitely. On timeout the AbortError is caught by the
+// A 5000ms abort timeout prevents a hanging server from blocking widget
+// bootstrap indefinitely while leaving enough headroom for the CORS
+// preflight round-trip. On timeout the TimeoutError is caught by the
 // existing catch block which logs a warning and returns {}.
 //
 // Note: keepalive is intentionally omitted — it conflicts with AbortSignal
@@ -28,8 +29,11 @@ export interface InitResponse {
 
 export type { ExperimentAssignment };
 
-/** Abort the init fetch after this many milliseconds to unblock widget bootstrap. */
-const INIT_TIMEOUT_MS = 1500;
+/** Abort the init fetch after this many milliseconds to unblock widget bootstrap.
+ *  5000ms gives cross-origin POST (with CORS preflight) enough headroom — the
+ *  OPTIONS round-trip + DNS + TLS + POST routinely takes 1-3s depending on
+ *  network conditions. 1500ms was too tight and caused spurious AbortErrors. */
+const INIT_TIMEOUT_MS = 5000;
 
 export async function fetchInitConfig(
   embedId: string | null,
@@ -39,7 +43,10 @@ export async function fetchInitConfig(
   if (!embedId) return {};
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), INIT_TIMEOUT_MS);
+  const timeoutId = setTimeout(
+    () => controller.abort(new DOMException('Init fetch timed out', 'TimeoutError')),
+    INIT_TIMEOUT_MS,
+  );
 
   try {
     const base = apiBase.replace(/\/$/, '');


### PR DESCRIPTION
## Problem
PR #66 increased `INIT_TIMEOUT_MS` from 1500ms to 5000ms but the unit tests still used the old timing values:
- `vi.advanceTimersByTimeAsync(2000)` — should be 6000 to trigger the new 5000ms timeout
- `vi.advanceTimersByTimeAsync(3000)` — should be 6000 to verify no leaked timer

## Fix
Updated both fake timer advances to 6000ms to match the new `INIT_TIMEOUT_MS = 5000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)