### PR TITLE
MMX-1027: fail loudly when /embed/init fails instead of mounting default config

### DIFF
--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchInitConfig, normalizeServerConfig } from './init';
+import { EmbedInitError, fetchInitConfig, normalizeServerConfig } from './init';
 
 describe('fetchInitConfig', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -8,9 +8,10 @@ describe('fetchInitConfig', () => {
     localStorage.clear();
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
-    // Failure paths intentionally console.warn — silence in tests so the
-    // suite output stays clean without losing the warning in production.
+    // Failure paths intentionally console.warn / console.error — silence in
+    // tests so the suite output stays clean without losing them in production.
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -41,16 +42,47 @@ describe('fetchInitConfig', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to empty config on fetch error', async () => {
+  // MMX-1027: in embedId mode a failed init MUST NOT resolve to {}. Returning
+  // {} made index.ts mount the widget on defaultConfig — a generic blue "Chat"
+  // widget with no token/agent_id, i.e. visibly wrong AND unable to chat. The
+  // failure is now surfaced as a typed EmbedInitError so the caller can refuse
+  // to mount and show an actionable message.
+
+  it('throws EmbedInitError with reason "network" on fetch error', async () => {
     fetchMock.mockRejectedValue(new Error('Network error'));
-    const result = await fetchInitConfig('emb_test123', 'https://api.memox.io');
-    expect(result).toEqual({});
+    await expect(fetchInitConfig('emb_test123', 'https://api.memox.io')).rejects.toMatchObject({
+      name: 'EmbedInitError',
+      reason: 'network',
+    });
   });
 
-  it('falls back to empty config on non-2xx response', async () => {
+  it('throws EmbedInitError with reason "origin" on 403 (origin not allowed)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Origin not allowed.' }), { status: 403 }),
+    );
+    const err = await fetchInitConfig('emb_test123', 'https://api.memox.io').catch((e) => e);
+    expect(err).toBeInstanceOf(EmbedInitError);
+    expect(err.reason).toBe('origin');
+    expect(err.status).toBe(403);
+  });
+
+  it('throws EmbedInitError with reason "not_found" on 404 (bad/inactive embedId)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Invalid or inactive embed configuration.' }), {
+        status: 404,
+      }),
+    );
+    const err = await fetchInitConfig('emb_test123', 'https://api.memox.io').catch((e) => e);
+    expect(err).toBeInstanceOf(EmbedInitError);
+    expect(err.reason).toBe('not_found');
+  });
+
+  it('throws EmbedInitError with reason "http" on other non-2xx responses', async () => {
     fetchMock.mockResolvedValue(new Response('nope', { status: 500 }));
-    const result = await fetchInitConfig('emb_test123', 'https://api.memox.io');
-    expect(result).toEqual({});
+    const err = await fetchInitConfig('emb_test123', 'https://api.memox.io').catch((e) => e);
+    expect(err).toBeInstanceOf(EmbedInitError);
+    expect(err.reason).toBe('http');
+    expect(err.status).toBe(500);
   });
 
   it('persists distinct_id in localStorage and reuses it on subsequent calls', async () => {
@@ -114,9 +146,13 @@ describe('fetchInitConfig', () => {
     ));
 
     const promise = fetchInitConfig('test-embed-id', 'https://api.example.com');
+    // Attach the rejection handler before advancing so the abort never lands
+    // as an unhandled rejection.
+    const settled = promise.catch((e) => e);
     await vi.advanceTimersByTimeAsync(6000);
-    const result = await promise;
-    expect(result).toEqual({});
+    const err = await settled;
+    expect(err).toBeInstanceOf(EmbedInitError);
+    expect(err.reason).toBe('timeout');
 
     vi.useRealTimers();
   });
@@ -144,12 +180,13 @@ describe('fetchInitConfig', () => {
     vi.useRealTimers();
   });
 
-  it('handles malformed JSON in 200 response (CDN error page)', async () => {
-    // Simulate CDN/proxy returning HTTP 200 with HTML error page instead of JSON
+  it('throws EmbedInitError on malformed JSON in a 200 response (CDN error page)', async () => {
+    // Simulate CDN/proxy returning HTTP 200 with an HTML error page instead of JSON
     fetchMock.mockResolvedValue(new Response('<html>503</html>', { status: 200 }));
-    const result = await fetchInitConfig('emb_test123', 'https://api.memox.io');
-    expect(result).toEqual({});
-    expect(console.warn).toHaveBeenCalled();
+    const err = await fetchInitConfig('emb_test123', 'https://api.memox.io').catch((e) => e);
+    expect(err).toBeInstanceOf(EmbedInitError);
+    expect(err.reason).toBe('bad_response');
+    expect(console.error).toHaveBeenCalled();
   });
 });
 

--- a/src/connection/init.test.ts
+++ b/src/connection/init.test.ts
@@ -130,7 +130,7 @@ describe('fetchInitConfig', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.memox.io/api/v1/embed/init/');
   });
 
-  it('aborts and returns {} when fetch hangs past INIT_TIMEOUT_MS', async () => {
+  it('aborts and throws EmbedInitError(timeout) when fetch hangs past INIT_TIMEOUT_MS', async () => {
     vi.useFakeTimers();
     vi.stubGlobal('fetch', vi.fn((_url: string, opts: RequestInit) =>
       new Promise<Response>((_resolve, reject) => {
@@ -157,6 +157,14 @@ describe('fetchInitConfig', () => {
     vi.useRealTimers();
   });
 
+  // Asserts the clearTimeout call directly. The previous version asserted that
+  // ``console.warn`` was never called, which could not fail: aborting an
+  // already-settled fetch is a no-op, so a leaked timer produced no log at all
+  // — the test passed with the clearTimeout removed entirely.
+  //
+  // Note we can't assert ``vi.getTimerCount() === 0`` either: getOrCreateDistinctId
+  // schedules its own timer that is still pending here, so the count is 1 even on
+  // the correct path.
   it('clears the timeout timer on successful fetch (no leaked timer)', async () => {
     vi.useFakeTimers();
     vi.stubGlobal('fetch', vi.fn((_url: string, _opts: RequestInit) =>
@@ -165,17 +173,20 @@ describe('fetchInitConfig', () => {
       ),
     ));
 
+    // Installed after useFakeTimers so we spy on the faked clearTimeout.
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+
     const result = await fetchInitConfig('emb', 'https://api.example.com');
     expect(result).toEqual({ foo: 'bar' });
 
-    // Advance well past INIT_TIMEOUT_MS. If clearTimeout was not called in
-    // the finally block, the abort callback would fire here and we'd see a
-    // console.warn call (abort on an already-resolved fetch). The spy on
-    // console.warn is set up in beforeEach — if it was called it means the
-    // timer leaked and fired.
+    // The finally block must clear the abort timer on the success path. Fails
+    // if the clearTimeout is removed — nothing else in this flow clears a timer.
+    expect(clearSpy).toHaveBeenCalled();
+
+    // Belt-and-braces: advancing past INIT_TIMEOUT_MS must not resurrect an
+    // abort or produce any failure logging.
     await vi.advanceTimersByTimeAsync(6000);
-    // console.warn should NOT have been called (no abort on a successful fetch)
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
 
     vi.useRealTimers();
   });

--- a/src/connection/init.ts
+++ b/src/connection/init.ts
@@ -3,16 +3,23 @@
 // attractor flags) plus an ``attractor_variant`` string that PostHog
 // stamps on every event.
 //
-// Failures here MUST NOT block the widget — if the embedId is missing or
-// the network is down, we fall through with an empty object and the
-// caller merges it on top of the local defaultConfig. Worst case: the
-// widget renders with the round/bubble defaults instead of the
-// per-embed attractor variant.
+// Failure policy (MMX-1027). In ``embedId`` mode this response is not
+// cosmetic: ``token``/``session_token``/``base_url``/``socket_url``/``org_id``/
+// ``agent_id`` ALL arrive here, so a widget that boots without it cannot
+// connect or chat. This function used to swallow every failure and return
+// ``{}``, which made the caller merge nothing onto ``defaultConfig`` and mount
+// a generic blue "Chat" widget — visibly not the operator's configuration and
+// silently inert. It now throws a typed ``EmbedInitError`` so the caller can
+// refuse to mount and surface an actionable message instead.
+//
+// Legacy local-config mode (no ``embedId``, everything supplied inline on
+// ``window.SimpleChatEmbedConfig``) never calls the endpoint and is unaffected:
+// it still short-circuits to ``{}``.
 //
 // A 5000ms abort timeout prevents a hanging server from blocking widget
 // bootstrap indefinitely while leaving enough headroom for the CORS
-// preflight round-trip. On timeout the TimeoutError is caught by the
-// existing catch block which logs a warning and returns {}.
+// preflight round-trip. On timeout the TimeoutError surfaces as an
+// ``EmbedInitError`` with reason ``'timeout'``.
 //
 // Note: keepalive is intentionally omitted — it conflicts with AbortSignal
 // in Chrome and Safari (browsers reject the combination), and keepalive is
@@ -28,6 +35,41 @@ export interface InitResponse {
 }
 
 export type { ExperimentAssignment };
+
+/**
+ * Why an ``/embed/init`` call failed. Drives the operator-facing copy in
+ * ``describeInitFailure`` — each reason maps to a different corrective action,
+ * which is the whole point of distinguishing them.
+ */
+export type EmbedInitFailureReason =
+  | 'origin' // 403 — host is not in the embed config's allowed_origins
+  | 'not_found' // 404 — embed_id unknown or inactive
+  | 'http' // other non-2xx
+  | 'bad_response' // 2xx whose body was not valid JSON (CDN/proxy error page)
+  | 'network' // fetch rejected — DNS, TLS, offline, CORS
+  | 'timeout'; // aborted after INIT_TIMEOUT_MS
+
+/** Typed failure from ``fetchInitConfig`` in embedId mode. */
+export class EmbedInitError extends Error {
+  readonly reason: EmbedInitFailureReason;
+  readonly status?: number;
+
+  constructor(message: string, reason: EmbedInitFailureReason, status?: number) {
+    super(message);
+    this.name = 'EmbedInitError';
+    this.reason = reason;
+    this.status = status;
+    // Required for ``instanceof`` to work when the bundle is transpiled to ES5.
+    Object.setPrototypeOf(this, EmbedInitError.prototype);
+  }
+}
+
+/** Map an HTTP status from ``/embed/init`` onto a failure reason. */
+function reasonForStatus(status: number): EmbedInitFailureReason {
+  if (status === 403) return 'origin';
+  if (status === 404) return 'not_found';
+  return 'http';
+}
 
 /** Abort the init fetch after this many milliseconds to unblock widget bootstrap.
  *  5000ms gives cross-origin POST (with CORS preflight) enough headroom — the
@@ -70,12 +112,22 @@ export async function fetchInitConfig(
       signal: controller.signal,
     });
 
-    if (!resp.ok) throw new Error(`init failed: ${resp.status}`);
+    if (!resp.ok) {
+      throw new EmbedInitError(
+        `init failed: ${resp.status}`,
+        reasonForStatus(resp.status),
+        resp.status,
+      );
+    }
     let data: any;
     try {
       data = await resp.json();
     } catch (parseError) {
-      throw new Error(`init response was not valid JSON: ${parseError}`);
+      throw new EmbedInitError(
+        `init response was not valid JSON: ${parseError}`,
+        'bad_response',
+        resp.status,
+      );
     }
     // Promote the top-level runtime fields onto the merged config so
     // the customer's HTML snippet only needs ``embedId`` — backend
@@ -103,12 +155,38 @@ export async function fetchInitConfig(
     }
     return { ...runtime, ...normalizeServerConfig(data.config || {}) };
   } catch (e) {
+    // Normalize everything into EmbedInitError so callers have one shape to
+    // branch on. An AbortError/TimeoutError here is our own abort controller
+    // firing; anything else that is not already typed is a transport failure.
+    const err =
+      e instanceof EmbedInitError
+        ? e
+        : isAbortLike(e)
+          ? new EmbedInitError('init fetch timed out', 'timeout')
+          : new EmbedInitError(
+              e instanceof Error ? e.message : String(e),
+              'network',
+            );
     // eslint-disable-next-line no-console
-    console.warn('[Memox] init fetch failed, falling back to local config', e);
-    return {};
+    console.error(
+      `[Memox] /embed/init failed (${err.reason}) — the chat widget will not be mounted.`,
+      err,
+    );
+    throw err;
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+/** True for the DOMException our AbortController raises on timeout. */
+function isAbortLike(e: unknown): boolean {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'name' in e &&
+    ((e as { name?: string }).name === 'AbortError' ||
+      (e as { name?: string }).name === 'TimeoutError')
+  );
 }
 
 

--- a/src/index.init-failure.test.ts
+++ b/src/index.init-failure.test.ts
@@ -1,0 +1,155 @@
+/**
+ * MMX-1027 — hard-fail on /embed/init failure (embedId mode).
+ *
+ * Before this change ``fetchInitConfig`` swallowed every failure and returned
+ * ``{}``, so ``init()`` merged nothing onto ``defaultConfig`` and mounted a
+ * fully generic widget (title "Chat", primary #0078d4). That widget was also
+ * inert — ``token``/``session_token``/``org_id``/``agent_id`` all arrive on the
+ * init response — so operators saw a plausible-looking chat widget that was
+ * neither their configuration nor able to chat.
+ *
+ * The contract now:
+ *   - the default-config widget is NEVER mounted after an init failure;
+ *   - every failure emits a console.error;
+ *   - inline mode (dashboard preview / playground) renders an actionable
+ *     panel naming the blocked host;
+ *   - floating mode (customer sites) renders nothing, so end visitors never
+ *     see Memox configuration guidance. The backend already logs the
+ *     rejection server-side for ops visibility.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchInitConfigMock } = vi.hoisted(() => ({ fetchInitConfigMock: vi.fn() }));
+
+vi.mock('./connection/init', async () => {
+  const actual = await vi.importActual<typeof import('./connection/init')>('./connection/init');
+  return { ...actual, fetchInitConfig: fetchInitConfigMock };
+});
+
+// Suppress network side effects from modules that init() touches.
+vi.mock('./analytics/posthog', () => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  group: vi.fn(),
+  setExperimentTags: vi.fn(),
+  __resetForTesting: vi.fn(),
+}));
+
+import { EmbedInitError } from './connection/init';
+
+/** Import ``./index`` fresh so its module-level bootstrap() runs again. */
+async function bootWidget(): Promise<void> {
+  vi.resetModules();
+  await import('./index');
+  // Let the awaited fetchInitConfig rejection propagate through init().
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('init failure (MMX-1027)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    fetchInitConfigMock.mockReset();
+    // Silence the intentional failure logging; asserted on via console.error.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as { MemoxChatConfig?: unknown }).MemoxChatConfig;
+    document.body.innerHTML = '';
+  });
+
+  it('inline mode: renders an actionable origin error and mounts no widget', async () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-mcx-preview-host', '');
+    document.body.appendChild(host);
+
+    window.MemoxChatConfig = {
+      embedId: 'emb_4cefe9c127e5',
+      mode: 'inline',
+      parentSelector: '[data-mcx-preview-host]',
+    } as unknown as typeof window.MemoxChatConfig;
+
+    fetchInitConfigMock.mockRejectedValue(
+      new EmbedInitError('init failed: 403', 'origin', 403),
+    );
+
+    await bootWidget();
+
+    const panel = host.querySelector('.mcx-embed-error');
+    expect(panel).not.toBeNull();
+
+    const text = panel?.textContent ?? '';
+    // Must name the blocked host and point at the exact setting to change.
+    expect(text).toContain(window.location.origin);
+    expect(text).toMatch(/allowed origins/i);
+
+    // The generic default-config widget must NOT have been mounted.
+    expect(document.getElementById('memox-chat-embed-host')).toBeNull();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('floating mode: renders nothing at all but still logs', async () => {
+    window.MemoxChatConfig = {
+      embedId: 'emb_4cefe9c127e5',
+    } as unknown as typeof window.MemoxChatConfig;
+
+    fetchInitConfigMock.mockRejectedValue(
+      new EmbedInitError('init failed: 403', 'origin', 403),
+    );
+
+    await bootWidget();
+
+    // Visitors on a customer site must never see internal config guidance.
+    expect(document.querySelector('.mcx-embed-error')).toBeNull();
+    expect(document.getElementById('memox-chat-embed-host')).toBeNull();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('inline mode: a 404 explains the embed ID rather than the origin', async () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-mcx-preview-host', '');
+    document.body.appendChild(host);
+
+    window.MemoxChatConfig = {
+      embedId: 'emb_does_not_exist',
+      mode: 'inline',
+      parentSelector: '[data-mcx-preview-host]',
+    } as unknown as typeof window.MemoxChatConfig;
+
+    fetchInitConfigMock.mockRejectedValue(
+      new EmbedInitError('init failed: 404', 'not_found', 404),
+    );
+
+    await bootWidget();
+
+    const text = host.querySelector('.mcx-embed-error')?.textContent ?? '';
+    expect(text).toMatch(/embed id/i);
+    expect(text).not.toMatch(/allowed origins/i);
+  });
+
+  it('inline mode: a network failure reports connectivity, not misconfiguration', async () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-mcx-preview-host', '');
+    document.body.appendChild(host);
+
+    window.MemoxChatConfig = {
+      embedId: 'emb_4cefe9c127e5',
+      mode: 'inline',
+      parentSelector: '[data-mcx-preview-host]',
+    } as unknown as typeof window.MemoxChatConfig;
+
+    fetchInitConfigMock.mockRejectedValue(
+      new EmbedInitError('Network error', 'network'),
+    );
+
+    await bootWidget();
+
+    const text = host.querySelector('.mcx-embed-error')?.textContent ?? '';
+    expect(text).toMatch(/couldn't reach|could not reach/i);
+    expect(text).not.toMatch(/allowed origins/i);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ import { normalizePhoneE164 } from './ui/forms/validation';
 import * as analytics from './analytics/posthog';
 import { postEmbedEvent } from './analytics/embed-events';
 import { getOrCreateDistinctId } from './utils/distinct-id';
-import { fetchInitConfig, normalizeServerConfig } from './connection/init';
+import { EmbedInitError, fetchInitConfig, normalizeServerConfig } from './connection/init';
+import { describeInitFailure, renderInitErrorPanel } from './ui/init-error-panel';
 import { applyTheme } from './ui/theme-vars';
 import { startEmbedConfigListener } from './connection/embed-config-listener';
 import type { MobileLauncherConfig } from './config/types';
@@ -105,6 +106,30 @@ declare global {
   }
 }
 
+/**
+ * Resolve the host element for inline mode: explicit selector, then the
+ * ``memox-chat-container`` ID convention, then the parent of the script tag
+ * that loaded us. Extracted so the init-failure path (MMX-1027) can render its
+ * error panel into exactly the container the widget would have mounted into.
+ */
+function resolveInlineParent(config: { parentSelector?: string }): HTMLElement | null {
+  let parent: HTMLElement | null = null;
+  if (config.parentSelector) {
+    parent = document.querySelector<HTMLElement>(config.parentSelector);
+  }
+  if (!parent) {
+    parent = document.getElementById('memox-chat-container');
+  }
+  if (!parent) {
+    const scripts = document.querySelectorAll('script[src*="chat-embed"]');
+    const lastScript = scripts[scripts.length - 1];
+    if (lastScript?.parentElement) {
+      parent = lastScript.parentElement;
+    }
+  }
+  return parent;
+}
+
 async function init(): Promise<void> {
   const userConfig = window.MemoxChatConfig || window.SimpleChatEmbedConfig || {};
   // Fetch server-side launcher + attractor config before merging. The
@@ -117,11 +142,41 @@ async function init(): Promise<void> {
   // Dev: hub-dev.memox.io). Without this default a customer pasting only
   // ``embedId`` would silently fail DNS on every init request.
   const apiBase = localConfig.apiBase || localConfig.apiUrl || 'https://hub.memox.io';
-  const serverConfig = await fetchInitConfig(
-    localConfig.embedId ?? null,
-    apiBase,
-    localConfig.disableExperiments,
-  );
+  // MMX-1027: in embedId mode a failed init is fatal, not cosmetic — the auth
+  // token, socket URL, org and agent all arrive on that response. Mounting the
+  // widget anyway (the old behaviour) produced a generic default-config widget
+  // that looked like a different bot and could never connect. Refuse to mount,
+  // and tell whoever can fix it what to fix. ``fetchInitConfig`` has already
+  // console.error'd the underlying failure by the time we get here.
+  let serverConfig: Record<string, unknown>;
+  try {
+    serverConfig = await fetchInitConfig(
+      localConfig.embedId ?? null,
+      apiBase,
+      localConfig.disableExperiments,
+    );
+  } catch (e) {
+    const err =
+      e instanceof EmbedInitError
+        ? e
+        : new EmbedInitError(e instanceof Error ? e.message : String(e), 'network');
+    // Always log the actionable message. In floating mode nothing renders at
+    // all, so the console is the ONLY signal a developer gets — it has to carry
+    // the fix, not just the failure.
+    const { title, detail } = describeInitFailure(err);
+    // eslint-disable-next-line no-console
+    console.error(`[Memox] ${title}. ${detail}`);
+    if (localConfig.mode === 'inline') {
+      // Inline mode is the dashboard preview / playground: the viewer is the
+      // operator, so show them the actionable message on-screen too.
+      // ``|| document.body`` mirrors the mount path below, so an unresolvable
+      // container degrades to a visible error rather than to no error at all.
+      renderInitErrorPanel(resolveInlineParent(localConfig) || document.body, err);
+    }
+    // Floating mode is a customer's live site — render nothing rather than
+    // exposing Memox configuration guidance to end visitors.
+    return;
+  }
   const config = mergeConfig(localConfig, serverConfig as Partial<ChatEmbedConfig>);
   // MMX-999: merge mobile launcher overrides when viewport ≤ 767px.
   applyMobileOverrides(config);
@@ -202,21 +257,7 @@ async function init(): Promise<void> {
 
   if (config.mode === 'inline') {
     // For inline mode, find parent container by selector, ID convention, or script tag's parent
-    let parent: HTMLElement | null = null;
-    if (config.parentSelector) {
-      parent = document.querySelector<HTMLElement>(config.parentSelector);
-    }
-    if (!parent) {
-      parent = document.getElementById('memox-chat-container');
-    }
-    if (!parent) {
-      // Find the script tag that loaded us and use its parent
-      const scripts = document.querySelectorAll('script[src*="chat-embed"]');
-      const lastScript = scripts[scripts.length - 1];
-      if (lastScript?.parentElement) {
-        parent = lastScript.parentElement;
-      }
-    }
+    const parent = resolveInlineParent(config);
     const result = createInlineShadowHost(parent || document.body);
     host = result.host;
     root = result.root;

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,10 +132,12 @@ function resolveInlineParent(config: { parentSelector?: string }): HTMLElement |
 
 async function init(): Promise<void> {
   const userConfig = window.MemoxChatConfig || window.SimpleChatEmbedConfig || {};
-  // Fetch server-side launcher + attractor config before merging. The
-  // server is the source of truth for ``launcher`` and ``attractor_variant``;
-  // local config provides everything else. Falls through to {} on failure
-  // so the widget always boots with at least the local defaults.
+  // Fetch server-side config before merging. The server is the source of truth
+  // for ``launcher`` and ``attractor_variant``; local config provides the rest.
+  // In embedId mode a failed fetch is FATAL and the widget does not mount — see
+  // the try/catch below. Do not reintroduce a silent fall-through to {}: that
+  // mounted a generic default-config widget that could never connect (MMX-1027).
+  // Only the legacy no-embedId path still resolves to {} without a request.
   const localConfig = mergeConfig(defaultConfig, userConfig);
   // Production hub hostname. ``api.memox.io`` does not resolve — confirmed
   // against ``repos/memox-hub/deploy/k8s/README.md`` (Prod: hub.memox.io,

--- a/src/ui/init-error-panel.ts
+++ b/src/ui/init-error-panel.ts
@@ -1,0 +1,128 @@
+/**
+ * Operator-facing panel shown when ``/embed/init`` fails (MMX-1027).
+ *
+ * Rendered ONLY in inline mode — that is the dashboard's Live Interactive
+ * Preview and the playground, i.e. surfaces where the person looking at it is
+ * the one who can fix the configuration. On customer sites (floating mode) the
+ * widget renders nothing instead, so end visitors never see Memox setup
+ * guidance; the backend already logs the rejection for ops visibility.
+ *
+ * Styling is inline rather than shadow-scoped: this is a few lines of static
+ * text, and inline declarations beat host-page selectors for the properties
+ * that matter, so the message stays legible without pulling in the widget's
+ * whole style pipeline.
+ */
+
+import type { EmbedInitFailureReason } from '../connection/init';
+import { EmbedInitError } from '../connection/init';
+
+export interface InitFailureCopy {
+  title: string;
+  detail: string;
+}
+
+/**
+ * Map a failure reason onto copy that names the corrective action. Each reason
+ * has a different fix, which is why they are distinguished at all — a generic
+ * "something went wrong" would leave the operator exactly where the silent
+ * fallback did.
+ */
+export function describeInitFailure(error: EmbedInitError): InitFailureCopy {
+  const reason: EmbedInitFailureReason = error.reason;
+  const origin = typeof location !== 'undefined' ? location.origin : 'this site';
+
+  switch (reason) {
+    case 'origin':
+      return {
+        title: 'Chat widget blocked on this site',
+        detail:
+          `${origin} is not listed in this embed's Allowed Origins. ` +
+          `Add it under Allowed Origins in the agent's chat embed settings, then reload this page.`,
+      };
+    case 'not_found':
+      return {
+        title: 'Chat widget not found',
+        detail:
+          `This embed ID is invalid or has been deactivated. ` +
+          `Check the embedId in your embed snippet against the agent's chat embed settings.`,
+      };
+    case 'timeout':
+      return {
+        title: 'Chat widget could not load',
+        detail: `Couldn't reach the Memox server in time. Check your connection, then reload this page.`,
+      };
+    case 'network':
+      return {
+        title: 'Chat widget could not load',
+        detail: `Couldn't reach the Memox server. Check your connection, then reload this page.`,
+      };
+    case 'bad_response':
+      return {
+        title: 'Chat widget could not load',
+        detail: `The Memox server returned an unexpected response. Reload the page, and if it persists contact Memox support.`,
+      };
+    case 'http':
+    default:
+      return {
+        title: 'Chat widget could not load',
+        detail:
+          `The Memox server returned an error` +
+          `${error.status ? ` (HTTP ${error.status})` : ''}. ` +
+          `Reload the page, and if it persists contact Memox support.`,
+      };
+  }
+}
+
+/**
+ * Build and mount the error panel inside ``parent``. Returns the element so
+ * callers (and tests) can inspect it.
+ */
+export function renderInitErrorPanel(parent: HTMLElement, error: EmbedInitError): HTMLElement {
+  const { title, detail } = describeInitFailure(error);
+
+  const panel = document.createElement('div');
+  panel.className = 'mcx-embed-error';
+  panel.setAttribute('role', 'alert');
+  panel.style.cssText = [
+    'box-sizing:border-box',
+    'display:flex',
+    'gap:10px',
+    'align-items:flex-start',
+    'margin:0',
+    'padding:16px',
+    'border:1px solid #f0c2c2',
+    'border-radius:8px',
+    'background:#fdf4f4',
+    'color:#7f1d1d',
+    "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif",
+    'font-size:13px',
+    'line-height:1.5',
+    'text-align:left',
+  ].join(';');
+
+  const icon = document.createElement('span');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '⚠';
+  icon.style.cssText = 'flex:0 0 auto;font-size:15px;line-height:1.35';
+
+  const body = document.createElement('div');
+  body.style.cssText = 'flex:1 1 auto;min-width:0';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'mcx-embed-error-title';
+  titleEl.textContent = title;
+  titleEl.style.cssText = 'font-weight:600;margin:0 0 4px';
+
+  const detailEl = document.createElement('div');
+  detailEl.className = 'mcx-embed-error-detail';
+  detailEl.textContent = detail;
+  detailEl.style.cssText = 'margin:0;overflow-wrap:anywhere';
+
+  body.appendChild(titleEl);
+  body.appendChild(detailEl);
+  panel.appendChild(icon);
+  panel.appendChild(body);
+  parent.appendChild(panel);
+
+  return panel;
+}


### PR DESCRIPTION
## Problem

The Live Interactive Preview on `platform.memox.io/agents/27` rendered what looked like a **different agent's bot**.

Root cause chain:

1. Agent 27's embed config (`emb_4cefe9c127e5`) had a non-empty `allowed_origins` that excluded `https://platform.memox.io`.
2. The preview mounts the real CDN widget on the dashboard origin, so the backend origin gate (`memox-hub` `memox_hub/embed_app/api/v1/views.py:163`) returned `403 {"detail":"Origin not allowed."}`.
3. `fetchInitConfig` swallowed it — `console.warn(...); return {}` — so `init()` merged nothing onto `defaultConfig` and mounted the widget's built-in generic widget (title "Chat", primary `#0078d4`).

It was never another agent's embed. It was our own defaults. And because `token`, `session_token`, `base_url`, `socket_url`, `org_id` and `agent_id` **all** arrive on that init response, the thing rendered could never have connected or chatted — it just looked plausible.

## Fix

Fail loudly, in `embedId` mode only:

- `fetchInitConfig` throws a typed `EmbedInitError` carrying a `reason` (`origin` / `not_found` / `http` / `bad_response` / `network` / `timeout`) and `status`.
- `init()` **never** mounts the widget after an init failure.
- Every failure `console.error`s an actionable message — the fix, not just the cause.
- **Inline mode** (dashboard preview, playground) renders an error panel naming the blocked host and the exact setting to change.
- **Floating mode** (customer sites) renders nothing. End visitors must never see Memox configuration guidance; the backend already logs rejections server-side for ops visibility.

Legacy local-config mode (no `embedId`) is unchanged — `fetchInitConfig` still short-circuits to `{}` without calling the endpoint.

### What an operator sees now

Inline / preview:

> ⚠ **Chat widget blocked on this site**
> `https://platform.memox.io` is not listed in this embed's Allowed Origins. Add it under Allowed Origins in the agent's chat embed settings, then reload this page.

Floating (console only):

```
[Memox] /embed/init failed (origin) — the chat widget will not be mounted. EmbedInitError: init failed: 403
[Memox] Chat widget blocked on this site. http://localhost:8099 is not listed in this embed's Allowed Origins. Add it under Allowed Origins in the agent's chat embed settings, then reload this page.
```

## Verification

- `npx vitest run` — **219 passed / 28 files**.
- `npx tsc --noEmit` — clean. `npx vite build` — clean (159.07 kB / 47.98 kB gzip).
- **Manual, against prod `hub.memox.io` from a disallowed origin** (built bundle served on `localhost:8099`): inline renders the panel and mounts no widget; floating renders nothing and logs the fix.
- **Mutation-tested both guards** — reintroducing the `return {}` fallback turns `init.test.ts` red (6 failures); removing the `init()` hard-fail turns `index.init-failure.test.ts` red (2 failures).

`dist/chat-embed.js` is intentionally **not** included — that is produced by the release workflow.

## Notes / follow-ups (not in this PR)

`InteractiveChatPreview.tsx:90` in `mmx-unified-chat` sets its "Connected" badge from `script.onload`, so it reports whether the CDN script downloaded, not whether the widget initialized. During this bug it displayed **"Connected"** over a dead widget. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpekB4YwwhFeBFRaUaina7